### PR TITLE
简化音色库选择并同步生成页

### DIFF
--- a/ai-kepu-video-web/frontend/src/components/VoicePicker.jsx
+++ b/ai-kepu-video-web/frontend/src/components/VoicePicker.jsx
@@ -22,14 +22,15 @@ export function VoicePicker({
   previewError = '',
   showAdvanced = true,
   includeUnavailable = false,
-  allowAvailabilityToggle = false,
+  manageAvailability = false,
+  optionsProvider = '',
   onAvailabilityChange,
   compact = false,
 }) {
   const normalized = normalizeVoiceCatalog(voices)
   const groups = groupVisibleVoices(normalized, { includeUnavailable })
   const selected = normalized.find(voice => voice.id === value)
-  const provider = selected?.provider || (String(value).startsWith('doubao:') ? 'doubao' : 'mimo')
+  const provider = selected?.provider || optionsProvider || (String(value).startsWith('doubao:') ? 'doubao' : 'mimo')
   const options = mergeTtsOptions({}, ttsOptions, provider)
 
   const updateOptions = patch => {
@@ -47,18 +48,25 @@ export function VoicePicker({
         <div className="voice-card-grid">
           {group.voices.map(voice => {
             const selectedVoice = voice.id === value
+            const checkedVoice = manageAvailability ? voice.is_enabled : selectedVoice
             const previewing = voice.id === playingVoice
-            return <article className={`voice-card${selectedVoice ? ' is-selected' : ''}${voice.selectable ? '' : ' is-unavailable'}`} key={voice.id}>
+            const cardSelectable = manageAvailability
+              ? voice.kind === 'preset' && voice.status === 'ready'
+              : voice.selectable
+            return <article className={`voice-card${checkedVoice ? ' is-selected' : ''}${cardSelectable ? '' : ' is-unavailable'}`} key={voice.id}>
               <button
                 type="button"
                 className="voice-card-select"
-                disabled={!voice.selectable}
-                aria-pressed={selectedVoice}
-                onClick={() => onChange?.(voice.id, voice)}
+                disabled={!cardSelectable}
+                aria-pressed={checkedVoice}
+                aria-label={manageAvailability ? `${checkedVoice ? '从生成列表移除' : '加入生成列表'}${voice.name}` : undefined}
+                onClick={() => manageAvailability
+                  ? onAvailabilityChange?.(voice.id, !voice.is_enabled)
+                  : onChange?.(voice.id, voice)}
               >
                 <span className="voice-avatar" aria-hidden="true">{voice.kind === 'clone' ? <Sparkles size={16} /> : voice.name.slice(0, 1)}</span>
                 <span className="voice-card-copy"><strong>{voice.name}</strong><small>{voice.kind === 'clone' ? '克隆音色' : voice.description || (voice.gender === 'male' ? '男声' : voice.gender === 'female' ? '女声' : '预置音色')}</small></span>
-                {selectedVoice ? <span className="voice-selected-mark"><Check size={13} /></span> : null}
+                {checkedVoice ? <span className="voice-selected-mark"><Check size={13} /></span> : null}
               </button>
               <button
                 type="button"
@@ -70,8 +78,7 @@ export function VoicePicker({
                 {previewing && previewLoading ? <LoaderCircle className="spin" size={15} /> : previewing ? <Pause size={15} /> : <Play size={15} />}
                 <span>{previewing ? '停止' : '试听'}</span>
               </button>
-              {!voice.selectable ? <span className="voice-status-label">{voice.status === 'draft' ? '待试听' : voice.status === 'failed' ? '试听失败' : '未开放'}</span> : null}
-              {allowAvailabilityToggle && voice.kind === 'preset' ? <label className="voice-availability-toggle"><input type="checkbox" checked={voice.is_enabled} onChange={event => onAvailabilityChange?.(voice.id, event.target.checked)} /><span>{voice.is_enabled ? '已开放' : '未开放'}</span></label> : null}
+              {!cardSelectable ? <span className="voice-status-label">{voice.status === 'draft' ? '待试听' : voice.status === 'failed' ? '试听失败' : '不可用'}</span> : null}
             </article>
           })}
         </div>
@@ -80,7 +87,7 @@ export function VoicePicker({
 
     {previewError ? <p className="voice-preview-error" role="alert"><CircleAlert size={15} />{previewError}</p> : null}
 
-    {showAdvanced && selected ? <section className="voice-advanced" aria-label="配音参数">
+    {showAdvanced && (selected || manageAvailability) ? <section className="voice-advanced" aria-label="配音参数">
       <label><span>语速</span><select value={options.speed_level} onChange={event => updateOptions({ speed_level: event.target.value })}>{SPEED_OPTIONS.map(([key, label]) => <option value={key} key={key}>{label}</option>)}</select></label>
       {provider === 'doubao'
         ? <label><span>音量 <strong>{options.volume_ratio.toFixed(1)}x</strong></span><input type="range" min="0.5" max="2" step="0.1" value={options.volume_ratio} onChange={event => updateOptions({ volume_ratio: Number(event.target.value) })} /></label>

--- a/ai-kepu-video-web/frontend/src/components/voice-picker.css
+++ b/ai-kepu-video-web/frontend/src/components/voice-picker.css
@@ -91,8 +91,6 @@
 
 .voice-preview-button:disabled { cursor: wait; opacity: .5; }
 .voice-status-label { position: absolute; right: 53px; bottom: 3px; color: #9b633d; font-size: 9px; }
-.voice-availability-toggle { position: absolute; left: 12px; bottom: 3px; display: flex; align-items: center; gap: 3px; color: #737d8d; font-size: 9px; }
-.voice-availability-toggle input { width: 11px; height: 11px; margin: 0; accent-color: #5d6ff0; }
 
 .voice-advanced {
   display: grid;

--- a/ai-kepu-video-web/frontend/src/lib/voiceCatalog.js
+++ b/ai-kepu-video-web/frontend/src/lib/voiceCatalog.js
@@ -46,6 +46,75 @@ export function groupVisibleVoices(voices, { includeUnavailable = false } = {}) 
   })).filter(group => group.voices.length)
 }
 
+export function togglePresetVoiceAvailability(input, voiceId) {
+  const voices = normalizeVoiceCatalog(input)
+  return voices.map(voice => {
+    if (voice.id !== voiceId || voice.kind !== 'preset' || voice.status !== 'ready') return voice
+    const isEnabled = !voice.is_enabled
+    return { ...voice, is_enabled: isEnabled, selectable: isEnabled }
+  })
+}
+
+export function resolveEnabledVoiceDefaults(input, defaults = {}, requestedProvider = 'doubao') {
+  const enabled = normalizeVoiceCatalog(input).filter(voice => voice.is_enabled && voice.status === 'ready')
+  const byProvider = {
+    doubao: enabled.filter(voice => voice.provider === 'doubao'),
+    mimo: enabled.filter(voice => voice.provider === 'mimo'),
+  }
+  const canonicalDefault = (provider, value) => {
+    const raw = String(value || '').trim()
+    if (!raw) return ''
+    if (raw.startsWith('mimo-clone:') || raw.startsWith(`${provider}:`)) return raw
+    return `${provider}:${raw}`
+  }
+  const nextDefaults = Object.fromEntries(['doubao', 'mimo'].map(provider => {
+    const current = canonicalDefault(provider, defaults[provider])
+    const next = byProvider[provider].some(voice => voice.id === current)
+      ? current
+      : byProvider[provider][0]?.id || ''
+    return [provider, next]
+  }))
+  const availableProviders = ['doubao', 'mimo'].filter(provider => byProvider[provider].length)
+  return {
+    provider: availableProviders.includes(requestedProvider) ? requestedProvider : availableProviders[0] || '',
+    availableProviders,
+    defaults: nextDefaults,
+  }
+}
+
+export function reconcileTtsVoiceConfig(tts = {}, input, activatedProvider = '') {
+  const resolved = resolveEnabledVoiceDefaults(input, {
+    doubao: tts.default_voice,
+    mimo: tts.mimo?.default_voice,
+  }, tts.provider)
+  let enabledProviders = (Array.isArray(tts.enabled_providers) ? tts.enabled_providers : [])
+    .filter(provider => resolved.availableProviders.includes(provider))
+  if (activatedProvider && resolved.availableProviders.includes(activatedProvider) && !enabledProviders.includes(activatedProvider)) {
+    enabledProviders = [...enabledProviders, activatedProvider]
+  }
+  if (!enabledProviders.length && resolved.provider) enabledProviders = [resolved.provider]
+  const provider = enabledProviders.includes(tts.provider)
+    ? tts.provider
+    : enabledProviders[0] || tts.provider || 'doubao'
+  const mimoDefault = resolved.defaults.mimo.startsWith('mimo-clone:')
+    ? resolved.defaults.mimo
+    : resolved.defaults.mimo.replace(/^mimo:/, '')
+  return {
+    ...tts,
+    provider,
+    enabled_providers: enabledProviders,
+    default_voice: resolved.defaults.doubao.replace(/^doubao:/, ''),
+    mimo: { ...(tts.mimo || {}), default_voice: mimoDefault },
+  }
+}
+
+export function hasUsableVoice(input, enabledProviders = []) {
+  const providers = new Set(enabledProviders)
+  return normalizeVoiceCatalog(input).some(voice => (
+    voice.is_enabled && voice.status === 'ready' && providers.has(voice.provider)
+  ))
+}
+
 export function mergeTtsOptions(base = {}, override = {}, provider = 'mimo') {
   const merged = { ...(base || {}), ...(override || {}) }
   const speedLevel = SPEED_LEVELS.has(merged.speed_level) ? merged.speed_level : 'normal'

--- a/ai-kepu-video-web/frontend/src/pages/ManuscriptPage.jsx
+++ b/ai-kepu-video-web/frontend/src/pages/ManuscriptPage.jsx
@@ -60,7 +60,17 @@ export function ManuscriptPage() {
   }, [draftId, navigate])
 
   useEffect(() => {
-    getVoices().then(result => setVoices(Array.isArray(result) ? result : [])).catch(() => setVoices([]))
+    getVoices().then(result => {
+      const available = Array.isArray(result) ? result : []
+      setVoices(available)
+      const current = draftRef.current
+      if (current.voice_type && !available.some(voice => voice.id === current.voice_type)) {
+        const next = { ...current, voice_type: '', voice_name: '' }
+        draftRef.current = next
+        setDraft(next)
+        saveDraft(next)
+      }
+    }).catch(() => setVoices([]))
   }, [])
 
   useEffect(() => {

--- a/ai-kepu-video-web/frontend/src/pages/ProductionSetupPage.jsx
+++ b/ai-kepu-video-web/frontend/src/pages/ProductionSetupPage.jsx
@@ -76,6 +76,7 @@ export function ProductionSetupPage() {
   const apiReady = Boolean(config) && missingApiItems.length === 0
 
   useEffect(() => {
+    let active = true
     const loaded = getDraft(draftId)
     if (!loaded) {
       toast.warning('未找到文稿草稿，请重新创建项目')
@@ -84,8 +85,19 @@ export function ProductionSetupPage() {
     }
     setDraft(loaded)
     Promise.all([getVoices(), getConfig()])
-      .then(([voiceList, runtimeConfig]) => { setVoices(normalizeVoiceCatalog(voiceList)); setConfig(runtimeConfig) })
-      .catch(() => toast.warning('未能读取完整配置，请确认后端服务在线'))
+      .then(([voiceList, runtimeConfig]) => {
+        if (!active) return
+        const available = normalizeVoiceCatalog(voiceList)
+        setVoices(available)
+        setConfig(runtimeConfig)
+        if (loaded.voice_type && !available.some(voice => voice.id === loaded.voice_type)) {
+          const fallback = available.find(voice => voice.id === defaultVoiceKey(runtimeConfig)) || available[0]
+          const next = saveDraft({ ...loaded, voice_type: fallback?.id || '', voice_name: fallback?.name || '' })
+          setDraft(next)
+        }
+      })
+      .catch(() => { if (active) toast.warning('未能读取完整配置，请确认后端服务在线') })
+    return () => { active = false }
   }, [draftId, navigate])
 
   const stopVoicePreview = useCallback(() => {

--- a/ai-kepu-video-web/frontend/src/pages/SettingsPage.jsx
+++ b/ai-kepu-video-web/frontend/src/pages/SettingsPage.jsx
@@ -58,7 +58,7 @@ import {
   switchProviderDraft,
 } from '../lib/llmProviderCatalog'
 import { toast } from '../lib/toast'
-import { nextPreviewState, normalizeVoiceCatalog } from '../lib/voiceCatalog'
+import { hasUsableVoice, nextPreviewState, normalizeVoiceCatalog, reconcileTtsVoiceConfig, togglePresetVoiceAvailability } from '../lib/voiceCatalog'
 import { normalizeMediaUrl } from '../utils/mediaUrl'
 import './delivery-pages.css'
 
@@ -118,7 +118,12 @@ export function SettingsPage() {
           .catch(error => ({ data: null, error })),
       ])
       if (loadGeneration !== loadGenerationRef.current) return
-      const normalized = normalizeConfig(config)
+      const normalizedVoices = normalizeVoiceCatalog(catalog)
+      const normalizedConfig = normalizeConfig(config)
+      const normalized = {
+        ...normalizedConfig,
+        tts: reconcileTtsVoiceConfig(normalizedConfig.tts, normalizedVoices),
+      }
       let providers = normalizeProviders(providerResult.data)
       if (!providers.length) {
         if (providerResult.error) console.warn('生文服务商目录加载失败，使用当前配置回退', providerResult.error)
@@ -166,7 +171,7 @@ export function SettingsPage() {
         ? { [initialized.llm.provider]: { ...initialized.llm, provider_options: { ...(initialized.llm.provider_options || {}) } } }
         : {}
       setProviderTab(normalized.tts.provider)
-      setVoices(normalizeVoiceCatalog(catalog))
+      setVoices(normalizedVoices)
       setClones(Array.isArray(cloneList) ? cloneList : [])
     } catch (error) {
       if (loadGeneration !== loadGenerationRef.current) return
@@ -338,34 +343,55 @@ export function SettingsPage() {
       getVoices({ include_disabled: true }),
       getVoiceClones({ include_hidden: true }),
     ])
-    setVoices(normalizeVoiceCatalog(catalog))
+    const normalizedVoices = normalizeVoiceCatalog(catalog)
+    setVoices(normalizedVoices)
+    setForm(current => ({
+      ...current,
+      tts: reconcileTtsVoiceConfig(current.tts, normalizedVoices),
+    }))
     setClones(Array.isArray(cloneList) ? cloneList : [])
   }, [])
 
   const setProviderEnabled = (provider, enabled) => {
+    const providerHasVoice = voices.some(voice => (
+      voice.provider === provider && voice.is_enabled && voice.status === 'ready'
+    ))
+    if (enabled && !providerHasVoice) {
+      toast.warning('请先在该服务商音色库中勾选至少一个音色')
+      return
+    }
+    const existing = form.tts.enabled_providers || []
+    let next = enabled
+      ? [...new Set([...existing, provider])]
+      : existing.filter(item => item !== provider)
+    if (!next.length) {
+      const fallback = ['doubao', 'mimo'].find(item => (
+        item !== provider && voices.some(voice => voice.provider === item && voice.is_enabled && voice.status === 'ready')
+      ))
+      if (!fallback) {
+        toast.warning('至少保留一个含可用音色的 TTS 服务商')
+        return
+      }
+      next = [fallback]
+    }
     setForm(current => {
-      const existing = current.tts.enabled_providers || []
-      let next = enabled
-        ? [...new Set([...existing, provider])]
-        : existing.filter(item => item !== provider)
-      if (!next.length) next = [provider === 'mimo' ? 'doubao' : 'mimo']
-      const defaultProvider = next.includes(current.tts.provider) ? current.tts.provider : next[0]
-      return { ...current, tts: { ...current.tts, enabled_providers: next, provider: defaultProvider } }
+      const tts = reconcileTtsVoiceConfig({ ...current.tts, enabled_providers: next }, voices)
+      return { ...current, tts }
     })
   }
 
-  const handleAvailabilityChange = (voiceId, enabled) => {
-    setVoices(current => current.map(voice => voice.id === voiceId
-      ? { ...voice, is_enabled: enabled, selectable: enabled && voice.status === 'ready' }
-      : voice))
-  }
-
-  const setAllProviderVoices = enabled => {
-    setVoices(current => current.map(voice => (
-      voice.provider === providerTab && voice.kind === 'preset'
-        ? { ...voice, is_enabled: enabled, selectable: enabled && voice.status === 'ready' }
-        : voice
-    )))
+  const handleAvailabilityChange = voiceId => {
+    const nextVoices = togglePresetVoiceAvailability(voices, voiceId)
+    const toggledVoice = nextVoices.find(voice => voice.id === voiceId)
+    setVoices(nextVoices)
+    setForm(current => ({
+      ...current,
+      tts: reconcileTtsVoiceConfig(
+        current.tts,
+        nextVoices,
+        toggledVoice?.is_enabled ? toggledVoice.provider : '',
+      ),
+    }))
   }
 
   const defaultVoiceKey = providerTab === 'mimo'
@@ -376,7 +402,7 @@ export function SettingsPage() {
       ? form.tts.default_voice
       : `doubao:${form.tts.default_voice}`
 
-  const providerVoices = voices.filter(voice => voice.provider === providerTab)
+  const providerVoices = voices.filter(voice => voice.provider === providerTab && voice.kind === 'preset')
   const providerOptions = providerTab === 'mimo'
     ? { speed_level: form.tts.mimo.speed_level, style_prompt: form.tts.mimo.style_prompt }
     : { speed_level: form.tts.speed_level, volume_ratio: form.tts.volume_ratio }
@@ -537,7 +563,12 @@ export function SettingsPage() {
   }
 
   const saveConfig = async () => {
-    const normalized = normalizeConfig(form)
+    const reconciledTts = reconcileTtsVoiceConfig(form.tts, voices)
+    if (!hasUsableVoice(voices, reconciledTts.enabled_providers)) {
+      toast.warning('至少保留一个可用音色')
+      return
+    }
+    const normalized = normalizeConfig({ ...form, tts: reconciledTts })
     const issue = validateConfig(normalized, selectedLlmProvider)
     if (issue) {
       toast.warning(issue)
@@ -648,8 +679,8 @@ export function SettingsPage() {
               : <MimoFields form={form} updateMimo={updateMimo} onRestore={() => setForm(current => restoreMimoTechnicalPreset(current))} />}
             <Field label="通用试听文本" wide><input value={form.tts.preview_text} maxLength="80" onChange={event => updateTts('preview_text', event.target.value)} placeholder="这是当前音色的试听。" /></Field>
             <div className="settings-voice-library">
-              <header><div><strong>{providerTab === 'mimo' ? 'MiMo' : '豆包'} 音色库</strong><small>勾选后才会在生产页和预览页出现。</small></div><span><button type="button" onClick={() => setAllProviderVoices(true)}>全选</button><button type="button" onClick={() => setAllProviderVoices(false)}>清空</button></span></header>
-              <VoicePicker voices={providerVoices} value={defaultVoiceKey} ttsOptions={providerOptions} onChange={selectDefaultVoice} onOptionsChange={updateProviderOptions} onPreview={handleVoicePreview} playingVoice={previewState.playingVoice} previewLoading={previewState.loading} previewError={previewState.error} includeUnavailable allowAvailabilityToggle onAvailabilityChange={handleAvailabilityChange} />
+              <header><div><strong>{providerTab === 'mimo' ? 'MiMo' : '豆包'} 音色库</strong><small>点击音色卡片切换对号；有对号的音色会出现在生成和预览页。</small></div></header>
+              <VoicePicker voices={providerVoices} value={defaultVoiceKey} ttsOptions={providerOptions} onChange={selectDefaultVoice} onOptionsChange={updateProviderOptions} onPreview={handleVoicePreview} playingVoice={previewState.playingVoice} previewLoading={previewState.loading} previewError={previewState.error} includeUnavailable manageAvailability optionsProvider={providerTab} onAvailabilityChange={handleAvailabilityChange} />
             </div>
             {providerTab === 'mimo' ? <div className="settings-clone-library">
               <header><div><strong>MiMo 声音克隆</strong><small>参考音频只保存在本地，试听成功后才能启用。</small></div></header>

--- a/ai-kepu-video-web/frontend/tests/voiceCatalog.test.mjs
+++ b/ai-kepu-video-web/frontend/tests/voiceCatalog.test.mjs
@@ -4,9 +4,13 @@ import test from 'node:test'
 import {
   buildVoiceTaskPayload,
   groupVisibleVoices,
+  hasUsableVoice,
   mergeTtsOptions,
   nextPreviewState,
   normalizeVoiceCatalog,
+  reconcileTtsVoiceConfig,
+  resolveEnabledVoiceDefaults,
+  togglePresetVoiceAvailability,
 } from '../src/lib/voiceCatalog.js'
 
 const catalog = [
@@ -38,6 +42,57 @@ test('groups only enabled ready voices for task pickers and retains all for sett
   const settings = groupVisibleVoices(normalized, { includeUnavailable: true })
   assert.equal(settings[0].voices.length, 4)
   assert.equal(settings[0].voices.find(voice => voice.name === '待试听').selectable, false)
+})
+
+test('toggles preset availability from the card and keeps unavailable clones unchanged', () => {
+  const enabled = togglePresetVoiceAvailability(catalog, 'mimo:茉莉')
+  assert.equal(enabled.find(voice => voice.id === 'mimo:茉莉').is_enabled, true)
+  assert.equal(enabled.find(voice => voice.id === 'mimo:茉莉').selectable, true)
+
+  const clones = togglePresetVoiceAvailability(enabled, 'mimo-clone:clone-draft')
+  assert.equal(clones.find(voice => voice.id === 'mimo-clone:clone-draft').is_enabled, false)
+})
+
+test('moves defaults to the first checked voice when the current default is removed', () => {
+  const voices = togglePresetVoiceAvailability(catalog, 'mimo:冰糖')
+  const resolved = resolveEnabledVoiceDefaults(voices, {
+    mimo: '冰糖',
+    doubao: 'zh_missing_voice',
+  }, 'mimo')
+
+  assert.equal(resolved.defaults.mimo, 'mimo-clone:clone-1')
+  assert.equal(resolved.defaults.doubao, 'doubao:zh_male_jieshuoxiaoming_moon_bigtts')
+  assert.equal(resolved.provider, 'mimo')
+})
+
+test('switches provider when a provider has no checked voices', () => {
+  const voices = togglePresetVoiceAvailability(catalog, 'doubao:zh_male_jieshuoxiaoming_moon_bigtts')
+  const resolved = resolveEnabledVoiceDefaults(voices, { doubao: 'zh_male_jieshuoxiaoming_moon_bigtts' }, 'doubao')
+
+  assert.equal(resolved.defaults.doubao, '')
+  assert.equal(resolved.provider, 'mimo')
+  assert.deepEqual(resolved.availableProviders, ['mimo'])
+})
+
+test('reconciles stale clone defaults and validates only enabled providers', () => {
+  const config = reconcileTtsVoiceConfig({
+    provider: 'mimo',
+    enabled_providers: ['mimo'],
+    default_voice: 'zh_male_jieshuoxiaoming_moon_bigtts',
+    mimo: { default_voice: 'mimo-clone:missing-clone' },
+  }, catalog)
+
+  assert.equal(config.mimo.default_voice, '冰糖')
+  assert.equal(config.provider, 'mimo')
+  assert.equal(hasUsableVoice(catalog, config.enabled_providers), true)
+  assert.equal(hasUsableVoice(catalog, ['missing-provider']), false)
+
+  const disabledCatalog = catalog.map(voice => ({ ...voice, is_enabled: false }))
+  const disabledConfig = reconcileTtsVoiceConfig(config, disabledCatalog)
+  assert.deepEqual(disabledConfig.enabled_providers, [])
+  assert.equal(disabledConfig.default_voice, '')
+  assert.equal(disabledConfig.mimo.default_voice, '')
+  assert.equal(hasUsableVoice(disabledCatalog, disabledConfig.enabled_providers), false)
 })
 
 test('merges inherited options and emits only provider-relevant task fields', () => {


### PR DESCRIPTION
## 这次改了什么

- 删除音色库的“全选 / 清空”和卡片内复选框，直接点击音色卡片切换对号
- 只把已勾选音色带到文稿与生成配置页；再次取消后同步从列表移除
- 当前默认音色被取消时自动落到同服务商第一个可用音色；无可用音色时切换到另一服务商
- 统一处理失效的本地克隆音色与旧草稿音色，避免继续提交不可用 voice ID
- 保留独立试听按钮以及 MiMo / 豆包参数设置

## 验证

- `npm test`：67 / 67 通过
- `npm run build`：通过
- `git diff --check`：通过
- 设置页实测：MiMo 9 张、豆包 10 张音色卡片均可通过整卡切换对号，无批量按钮和复选框
