### PR TITLE
docs: 前置剪映与 CapCut 搜索关键词

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# InsightCut
+# InsightCut — Jianying / 剪映 / CapCut AI 图片视频工作台
 
 > 把文稿真正做成可修改、可恢复、还能继续精修的视频项目。
 


### PR DESCRIPTION
## 变更

- README 主标题前置 `Jianying / 剪映 / CapCut`
- 保持仓库名 `ai-jianying-image-video` 不变
- GitHub About 与 Topics 已同步为高意图搜索词

## 原因

现有仓库名已经积累了剪映相关搜索权重。本次通过标题、描述和 Topics 强化检索语义，避免重命名造成不必要的链接与品牌迁移成本。

## 验证

- `git diff --check`
- README 五个真实成片案例及排序未改变
- GitHub About、Topics 已回读确认