### PR TITLE
feat: InsightCut 品牌首页、真实案例与完整文档

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,3 +234,46 @@ jobs:
           mkdir -p "$RUNNER_TEMP/scan-tree"
           git archive HEAD | tar -x -C "$RUNNER_TEMP/scan-tree"
           "$(go env GOPATH)/bin/gitleaks" dir "$RUNNER_TEMP/scan-tree" --redact --config .gitleaks.toml
+
+  website:
+    name: Website build and browser checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.11'
+          cache: pip
+          cache-dependency-path: ai-kepu-video-server/requirements-dev.lock
+      - name: Install locked site builder
+        run: python -m pip install --require-hashes -r ai-kepu-video-server/requirements-dev.lock
+      - name: Build and verify legacy links
+        run: |
+          python scripts/build_site.py
+          python scripts/check_site.py
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: ai-kepu-video-web/frontend/package-lock.json
+      - name: Check phone, tablet, desktop and actual video playback
+        working-directory: ai-kepu-video-web/frontend
+        run: |
+          npm ci
+          npx playwright install --with-deps chromium
+          npx playwright test --config=playwright.site.config.js
+      - name: Preserve website screenshots and failure traces
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: website-evidence
+          retention-days: 7
+          path: ai-kepu-video-web/frontend/test-results-site/
+      - name: Save verified site for publication
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: pages-site
+          retention-days: 7
+          path: site-dist/
+          include-hidden-files: true

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ ci-evidence/
 test-results-browser/
 test-results-fullstack/
 playwright-report/
+site-dist/
+site-test-dist/
+test-results-site/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,3 +157,9 @@ npm run dev
 - 开发/CI 安装后端 requirements-dev.lock（含哈希），更新锁使用 uv pip compile requirements-dev.txt --python-version 3.11 --universal --generate-hashes --output-file requirements-dev.lock。
 - 日常前后端端口仍为 2001/2002；隔离全栈测试默认 2101/2102，浏览器测试 2103，不复用开发服务。
 - 运行 ruff check src api_server.py、npm run lint、scripts/check_contribution.py；完整产物验证运行 scripts/verify_local_flow.py。
+
+### 项目网站
+
+- GitHub Pages 是公开产品介绍与文档站，工作台仍在本机 2001/2002 运行。沿用 `docs/assets/` 品牌素材；案例来自 `docs/showcase/`，禁止把本机运行数据复制到站点。
+- `python scripts/build_site.py` 仅发布 Git 登记的文档与静态资产，构建到 `site-dist/`；`python scripts/check_site.py` 检查全部本地链接。
+- 在前端目录运行 `npx playwright test --config=playwright.site.config.js` 验证 390/768/1440 宽度、真实视频播放与文档，预览服务使用独立端口 2104。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,3 +157,9 @@ npm run dev
 - 开发/CI 安装后端 requirements-dev.lock（含哈希），更新锁使用 uv pip compile requirements-dev.txt --python-version 3.11 --universal --generate-hashes --output-file requirements-dev.lock。
 - 日常前后端端口仍为 2001/2002；隔离全栈测试默认 2101/2102，浏览器测试 2103，不复用开发服务。
 - 运行 ruff check src api_server.py、npm run lint、scripts/check_contribution.py；完整产物验证运行 scripts/verify_local_flow.py。
+
+### 项目网站
+
+- GitHub Pages 是公开产品介绍与文档站，工作台仍在本机 2001/2002 运行。沿用 `docs/assets/` 品牌素材；案例来自 `docs/showcase/`，禁止把本机运行数据复制到站点。
+- `python scripts/build_site.py` 仅发布 Git 登记的文档与静态资产，构建到 `site-dist/`；`python scripts/check_site.py` 检查全部本地链接。
+- 在前端目录运行 `npx playwright test --config=playwright.site.config.js` 验证 390/768/1440 宽度、真实视频播放与文档，预览服务使用独立端口 2104。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,3 +72,7 @@ UI 修改附桌面/手机截图；产物变化附压缩后的视频或结构验�
 - 提交贡献表示你有权提交相关内容，并同意其贡献以本项目 [MIT](LICENSE) 许可证提供。保留第三方许可证、版权与署名。
 - MIT 覆盖本项目有权授权的软件；第三方商标、服务商 API、依赖及非自有媒体仍遵循其原有条款。
 - 单维护者当前不要求其自己的 PR 获得第二人批准，但必须走 PR 和全部必需 CI。外部 PR 必须经过维护者审查。任何日常发布不得使用管理员绕过。
+
+## 产品网站
+
+网站源码在 `docs/index.html` 与 `docs/assets/site.*`。修改后从根目录运行 `python scripts/build_site.py`、`python scripts/check_site.py`，再在前端目录运行 `npx playwright test --config=playwright.site.config.js`。构建器只处理 Git 登记的公开文件；新增页面请先 `git add`，不需要先提交。截图和失败 trace 在 `test-results-site/`，网站测试使用独立端口 2104。

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
     <a href="https://skynotsilent.github.io/insightcut-jianying-image-video/showcase/"><strong>成片案例</strong></a>
     · <a href="#从零开始使用"><strong>快速开始</strong></a>
     · <a href="#从一句输入开始"><strong>产品界面</strong></a>
-    · <a href="docs/"><strong>项目文档</strong></a>
+    · <a href="https://skynotsilent.github.io/insightcut-jianying-image-video/"><strong>项目主页与文档</strong></a>
     · <a href="https://github.com/SkyNotSilent/insightcut-jianying-image-video/issues"><strong>问题反馈</strong></a>
   </p>
 </div>
@@ -220,7 +220,7 @@ npm run dev
 
 ### 5. 完成第一次生成
 
-回到文稿页，输入一个主题，或者切换到文稿模式粘贴完整内容。选择画面比例与视觉风格后生成内容预案；进入生产工作台检查文稿、分镜和提示词，确认音色后再生成图片与配音。素材会在同一页面逐段出现，可以直接连续预览，最后再按需要生成完整视频预览、MP4 或剪映草稿。
+回到文稿页，输入一个主题，或者切换到文稿模式粘贴完整内容。选择画面比例与视觉风格后生成内容预案；按需预览并编辑文稿、分镜和提示词，然后确认生产。图片、配音与 MP4 会在后台连续推进，无需中途再点击生成；剪映草稿在导出页按需构建。
 
 ### 6. 把结果写入剪映
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -22,7 +22,7 @@
     <a href="https://skynotsilent.github.io/insightcut-jianying-image-video/showcase/"><strong>Showcase</strong></a>
     · <a href="#quick-start"><strong>Quick Start</strong></a>
     · <a href="#start-from-one-line"><strong>Product Tour</strong></a>
-    · <a href="docs/"><strong>Documentation</strong></a>
+    · <a href="https://skynotsilent.github.io/insightcut-jianying-image-video/"><strong>Website &amp; docs</strong></a>
     · <a href="https://github.com/SkyNotSilent/insightcut-jianying-image-video/issues"><strong>Issues</strong></a>
   </p>
 </div>

--- a/ai-kepu-video-server/requirements-dev.lock
+++ b/ai-kepu-video-server/requirements-dev.lock
@@ -864,7 +864,9 @@ litellm==1.100.1 \
 markdown-it-py==4.2.0 \
     --hash=sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49 \
     --hash=sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a
-    # via rich
+    # via
+    #   -r requirements-dev.txt
+    #   rich
 markupsafe==3.0.3 \
     --hash=sha256:0303439a41979d9e74d18ff5e2dd8c43ed6c6001fd40e5bf2e43f7bd9bbc523f \
     --hash=sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a \

--- a/ai-kepu-video-server/requirements-dev.txt
+++ b/ai-kepu-video-server/requirements-dev.txt
@@ -2,3 +2,4 @@
 pytest>=9.0.3,<10
 pip-audit>=2.9,<3
 ruff==0.16.7
+markdown-it-py==4.2.0

--- a/ai-kepu-video-web/frontend/playwright.site.config.js
+++ b/ai-kepu-video-web/frontend/playwright.site.config.js
@@ -1,0 +1,16 @@
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './site-e2e',
+  outputDir: 'test-results-site',
+  workers: 1,
+  retries: 0,
+  reporter: [['list']],
+  use: { baseURL: 'http://127.0.0.1:2104', ...devices['Desktop Chrome'], screenshot: 'only-on-failure', trace: 'retain-on-failure' },
+  webServer: {
+    command: 'node ../../scripts/serve_site.mjs',
+    url: 'http://127.0.0.1:2104',
+    reuseExistingServer: false,
+    timeout: 10000,
+  },
+})

--- a/ai-kepu-video-web/frontend/site-e2e/evidence-probe.spec.js
+++ b/ai-kepu-video-web/frontend/site-e2e/evidence-probe.spec.js
@@ -1,7 +1,0 @@
-import { test, expect } from '@playwright/test'
-
-// Temporary release-gate drill; removed after the failed run is inspected.
-test('intentional failure verifies screenshot and trace retention', async ({ page }) => {
-  await page.goto('/')
-  await expect(page).toHaveTitle('INTENTIONAL CI EVIDENCE PROBE', { timeout: 1000 })
-})

--- a/ai-kepu-video-web/frontend/site-e2e/evidence-probe.spec.js
+++ b/ai-kepu-video-web/frontend/site-e2e/evidence-probe.spec.js
@@ -1,0 +1,7 @@
+import { test, expect } from '@playwright/test'
+
+// Temporary release-gate drill; removed after the failed run is inspected.
+test('intentional failure verifies screenshot and trace retention', async ({ page }) => {
+  await page.goto('/')
+  await expect(page).toHaveTitle('INTENTIONAL CI EVIDENCE PROBE', { timeout: 1000 })
+})

--- a/ai-kepu-video-web/frontend/site-e2e/site.spec.js
+++ b/ai-kepu-video-web/frontend/site-e2e/site.spec.js
@@ -1,0 +1,61 @@
+import { test, expect } from '@playwright/test'
+
+for (const width of [390, 768, 1440]) {
+  test(`homepage at ${width}px: complete layout and real images`, async ({ page }, testInfo) => {
+    const errors = []
+    page.on('pageerror', error => errors.push(error.message))
+    page.on('response', response => { if (response.status() >= 400) errors.push(`${response.status()} ${response.url()}`) })
+    await page.setViewportSize({ width, height: 950 })
+    await page.goto('/')
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('让想法')
+    await page.screenshot({ path: testInfo.outputPath(`hero-${width}.png`), animations: 'disabled' })
+    // Scroll the full page so all lazy screenshot assets are actually requested.
+    await page.locator('footer').scrollIntoViewIfNeeded()
+    await expect.poll(() => page.locator('img').evaluateAll(images => images.every(image => image.complete && image.naturalWidth > 0))).toBe(true)
+    await expect.poll(() => page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(true)
+    await page.evaluate(() => window.scrollTo({ top: 0, behavior: 'instant' }))
+    await page.screenshot({ path: testInfo.outputPath(`home-${width}.png`), fullPage: true, animations: 'disabled' })
+    expect(errors).toEqual([])
+  })
+}
+
+test('videos really play, seek and pause each other', async ({ page }) => {
+  await page.goto('/')
+  const first = page.locator('video').nth(0)
+  await first.scrollIntoViewIfNeeded()
+  await first.evaluate(async video => { video.muted = true; await video.play() })
+  await expect.poll(() => first.evaluate(video => video.currentTime)).toBeGreaterThan(0.15)
+  await first.evaluate(video => { video.currentTime = 12 })
+  await expect.poll(() => first.evaluate(video => video.currentTime)).toBeGreaterThan(12)
+  const second = page.locator('video').nth(1)
+  await second.evaluate(async video => { video.muted = true; await video.play() })
+  await expect.poll(() => second.evaluate(video => video.currentTime)).toBeGreaterThan(0.15)
+  await expect.poll(() => first.evaluate(video => video.paused)).toBe(true)
+})
+
+test('keyboard access, copy and published document routes', async ({ page, context }) => {
+  await context.grantPermissions(['clipboard-read', 'clipboard-write'])
+  await page.goto('/')
+  await page.keyboard.press('Tab')
+  await expect(page.getByRole('link', { name: '跳到正文' })).toBeFocused()
+  await page.getByRole('button', { name: '复制命令' }).click()
+  await expect(page.getByRole('status')).toContainText('已复制')
+  expect(await page.evaluate(() => navigator.clipboard.readText())).toContain('git clone https://github.com/SkyNotSilent/')
+  await page.getByRole('link', { name: '安装与快速开始' }).click()
+  await expect(page.getByRole('heading', { level: 1 })).toHaveText('开始使用 InsightCut')
+  for (const route of ['/engineering-workflow.html', '/batch-video-workflow.html', '/contributing.html', '/license.html', '/showcase/']) {
+    const response = await page.goto(route)
+    expect(response.status()).toBe(200)
+    await expect(page.getByRole('heading', { level: 1 })).toBeVisible()
+  }
+})
+
+test('video Range and HEAD requests remain available', async ({ request }) => {
+  const url = '/showcase/videos/book-16x9.mp4'
+  const head = await request.head(url)
+  expect(head.status()).toBe(200)
+  expect(Number(head.headers()['content-length'])).toBeGreaterThan(1000)
+  const range = await request.get(url, { headers: { Range: 'bytes=0-1023' } })
+  expect(range.status()).toBe(206)
+  expect((await range.body()).length).toBe(1024)
+})

--- a/docs/assets/site.css
+++ b/docs/assets/site.css
@@ -1,0 +1,1040 @@
+:root {
+  --blue: #315fea;
+  --orange: #d46f44;
+  --ink: #172033;
+  --muted: #616b7c;
+  --paper: #f7f8fc;
+  --line: #dde2ec;
+  --font:
+    "Avenir Next", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei",
+    sans-serif;
+  color-scheme: light;
+  font-family: var(--font);
+  color: var(--ink);
+  background: var(--paper);
+  font-synthesis: none;
+}
+* {
+  box-sizing: border-box;
+}
+html {
+  scroll-behavior: smooth;
+  scroll-padding-top: 30px;
+}
+body {
+  margin: 0;
+}
+a {
+  color: inherit;
+  text-decoration: none;
+}
+button {
+  font: inherit;
+}
+a,
+button {
+  touch-action: manipulation;
+}
+a:focus-visible,
+button:focus-visible,
+video:focus-visible {
+  outline: 3px solid var(--blue);
+  outline-offset: 5px;
+}
+img {
+  max-width: 100%;
+  display: block;
+  height: auto;
+}
+video {
+  max-width: 100%;
+}
+h1,
+h2,
+h3,
+p,
+figure {
+  margin: 0;
+}
+button,
+a {
+  -webkit-tap-highlight-color: transparent;
+}
+.wrap {
+  width: min(1200px, calc(100% - 96px));
+  margin-inline: auto;
+}
+.skip-link {
+  position: fixed;
+  top: -80px;
+  left: 20px;
+  padding: 12px 20px;
+  background: var(--ink);
+  color: white;
+  z-index: 99;
+}
+.skip-link:focus {
+  top: 10px;
+}
+.site-header {
+  height: 104px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--line);
+}
+.brand {
+  display: inline-flex;
+  gap: 10px;
+  align-items: center;
+  font-size: 23px;
+  font-weight: 750;
+  letter-spacing: -0.8px;
+}
+.brand-dot {
+  color: var(--orange);
+}
+nav {
+  display: flex;
+  align-items: center;
+  gap: 34px;
+  font-size: 14px;
+  font-weight: 600;
+}
+nav a {
+  padding-block: 10px;
+}
+nav a:hover {
+  color: var(--blue);
+}
+.nav-github {
+  border: 1px solid #c9d0de;
+  border-radius: 50px;
+  padding: 10px 19px;
+}
+.nav-github span {
+  margin-left: 12px;
+}
+.hero {
+  padding-top: 42px;
+}
+.hero-topline,
+.hero-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.eyebrow {
+  font-size: 11px;
+  letter-spacing: 1.8px;
+  line-height: 1.7;
+  font-weight: 700;
+}
+.status-dot {
+  display: inline-block;
+  vertical-align: 1px;
+  width: 6px;
+  height: 6px;
+  background: var(--blue);
+  border-radius: 50%;
+  margin-right: 10px;
+}
+.edition {
+  font-size: 10px;
+  letter-spacing: 1.7px;
+  color: var(--muted);
+}
+.hero-copy {
+  display: grid;
+  grid-template-columns: 1.25fr 1fr;
+  align-items: end;
+  gap: 50px;
+  padding: 39px 0 58px;
+}
+h1 {
+  font-size: clamp(64px, 6.5vw, 94px);
+  line-height: 1.14;
+  letter-spacing: -6px;
+  font-weight: 650;
+}
+h1 > span {
+  color: var(--blue);
+}
+.orange-period {
+  color: var(--orange);
+}
+.hero-description {
+  padding: 0 0 7px 28px;
+}
+.hero-description > p:first-child {
+  font-size: 20px;
+  line-height: 1.85;
+  letter-spacing: 0.3px;
+}
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  margin-top: 27px;
+}
+.button {
+  min-height: 50px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 32px;
+  font-size: 14px;
+  font-weight: 650;
+  padding: 15px 22px;
+  border-radius: 5px;
+  transition:
+    transform 0.2s,
+    background 0.2s;
+}
+.button:hover {
+  transform: translateY(-2px);
+  background: #214ed2;
+}
+.primary {
+  background: var(--blue);
+  color: white;
+}
+.text-link {
+  font-size: 13px;
+  font-weight: 650;
+  display: inline-flex;
+  align-items: center;
+  gap: 17px;
+  line-height: 1.7;
+}
+.text-link:hover {
+  color: var(--blue);
+}
+.small-note {
+  margin-top: 19px;
+  font-size: 10px;
+  color: var(--muted);
+  letter-spacing: 0.15px;
+}
+.studio-window {
+  background: white;
+  border: 1px solid #d3d9e5;
+  border-radius: 11px;
+  overflow: hidden;
+  box-shadow: 0 18px 65px -28px #27374e44;
+}
+.window-bar {
+  padding: 12px 19px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 8px;
+  letter-spacing: 1.4px;
+  background: #f0f2f6;
+  color: #637082;
+}
+.window-dots {
+  display: flex;
+  gap: 5px;
+  width: 120px;
+}
+.window-dots i {
+  width: 6px;
+  height: 6px;
+  background: #c2c9d5;
+  border-radius: 50%;
+}
+.window-local {
+  width: 120px;
+  text-align: right;
+}
+.studio-window > img {
+  width: 100%;
+}
+.studio-window figcaption {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 11px;
+  padding: 15px 22px;
+  border-top: 1px solid var(--line);
+  color: var(--muted);
+}
+.studio-window figcaption b {
+  font-weight: 600;
+  color: var(--orange);
+  margin-right: 10px;
+}
+.studio-window figcaption > span:last-child {
+  font-size: 9px;
+}
+.hero-foot {
+  font-size: 11px;
+  letter-spacing: 0.3px;
+  padding: 23px 0 12px;
+  color: var(--muted);
+}
+.section-pad {
+  padding-top: 110px;
+  padding-bottom: 110px;
+}
+.section-heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: end;
+  margin-bottom: 43px;
+  gap: 36px;
+}
+.section-heading .eyebrow {
+  color: var(--muted);
+  margin-bottom: 18px;
+}
+h2 {
+  font-size: clamp(32px, 3.2vw, 46px);
+  line-height: 1.35;
+  letter-spacing: -1.7px;
+  font-weight: 600;
+}
+.section-heading > p {
+  font-size: 14px;
+  line-height: 1.9;
+  color: var(--muted);
+  padding-bottom: 5px;
+}
+.work-section {
+  background: #edf0f6;
+  margin-top: 64px;
+}
+.film-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 25px;
+}
+.film-player {
+  position: relative;
+  aspect-ratio: 16/9;
+  background: #172033;
+  overflow: hidden;
+  border-radius: 5px;
+}
+.film-player video {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+.film-index {
+  position: absolute;
+  top: 13px;
+  left: 13px;
+  background: #17203366;
+  color: white;
+  padding: 3px 7px;
+  border-radius: 3px;
+  font-size: 10px;
+  pointer-events: none;
+}
+.film-meta {
+  padding-top: 22px;
+}
+.film-meta > span {
+  font-size: 10px;
+  letter-spacing: 0.6px;
+  color: #6a7384;
+}
+.film-meta h3 {
+  font-size: 23px;
+  line-height: 1.45;
+  letter-spacing: -0.4px;
+  font-weight: 600;
+  margin-top: 12px;
+  min-height: 67px;
+}
+.film-meta p {
+  font-size: 12px;
+  color: var(--muted);
+  line-height: 1.8;
+  margin-top: 13px;
+}
+.gallery-link {
+  margin-top: 36px;
+  border-bottom: 1px solid #b3bdce;
+  padding-bottom: 8px;
+}
+.feature-row {
+  display: grid;
+  grid-template-columns: 0.75fr 1.25fr;
+  gap: 70px;
+  align-items: center;
+  padding: 52px 0;
+  border-top: 1px solid var(--line);
+}
+.feature-copy h3 {
+  font-size: 30px;
+  font-weight: 600;
+  line-height: 1.5;
+  letter-spacing: -1px;
+  margin: 20px 0 17px;
+}
+.feature-copy p {
+  font-size: 14px;
+  line-height: 1.95;
+  color: var(--muted);
+  max-width: 340px;
+}
+.feature-copy a {
+  margin-top: 21px;
+}
+.step-number {
+  color: var(--orange);
+  font-size: 11px;
+  letter-spacing: 1.2px;
+  font-weight: 650;
+}
+.feature-image {
+  background: #e9edf5;
+  padding: 20px;
+  border-radius: 8px;
+  display: block;
+  transition: background 0.2s;
+}
+.feature-image:hover {
+  background: #dfe6f4;
+}
+.feature-image img {
+  width: 100%;
+  border-radius: 4px;
+  box-shadow: 0 5px 15px #1720330f;
+}
+.reversed {
+  grid-template-columns: 1.25fr 0.75fr;
+}
+.reversed .feature-copy {
+  grid-column: 2;
+  grid-row: 1;
+}
+.reversed .feature-image {
+  grid-column: 1;
+  grid-row: 1;
+}
+.export-note {
+  padding: 35px 0 0;
+  display: flex;
+  gap: 30px;
+  align-items: center;
+  border-top: 1px solid var(--line);
+}
+.export-symbol {
+  width: 72px;
+  min-width: 72px;
+  height: 72px;
+  border: 1px solid #c5cde0;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  font-size: 35px;
+  color: var(--blue);
+}
+.export-note h3 {
+  font-size: 23px;
+  font-weight: 600;
+  margin: 9px 0;
+}
+.export-note p {
+  font-size: 13px;
+  line-height: 1.9;
+  color: var(--muted);
+  max-width: 630px;
+}
+.format-label {
+  font-size: 10px;
+  color: var(--muted);
+  line-height: 1.9;
+  margin-left: auto;
+  white-space: nowrap;
+  letter-spacing: 0.6px;
+}
+.principles {
+  background: var(--ink);
+  color: #fff;
+}
+.principles-inner {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 85px;
+}
+.principles .eyebrow {
+  color: #aab7d8;
+  margin-bottom: 21px;
+}
+.principle-list {
+  display: grid;
+  gap: 29px;
+}
+.principle-list > div {
+  display: flex;
+  gap: 23px;
+  padding-bottom: 28px;
+  border-bottom: 1px solid #ffffff26;
+}
+.principle-list > div:last-child {
+  border: 0;
+  padding: 0;
+}
+.principle-list > div > span {
+  font-size: 11px;
+  color: #cda58e;
+  padding-top: 5px;
+}
+.principle-list h3 {
+  font-size: 19px;
+  font-weight: 500;
+  margin-bottom: 11px;
+}
+.principle-list p {
+  font-size: 13px;
+  color: #c0c8d8;
+  line-height: 1.9;
+}
+.start-heading {
+  text-align: center;
+}
+.start-heading h2 {
+  font-size: clamp(36px, 4.1vw, 58px);
+  margin: 23px 0 19px;
+}
+.start-heading h2 span {
+  color: var(--blue);
+}
+.start-heading > p:last-child {
+  font-size: 14px;
+  color: var(--muted);
+  line-height: 1.9;
+}
+.start-grid {
+  margin: 48px auto 0;
+  display: grid;
+  grid-template-columns: 1.45fr 1fr;
+  gap: 45px;
+  max-width: 1000px;
+}
+.install-panel {
+  background: white;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  min-width: 0;
+}
+.install-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 21px;
+  font-size: 12px;
+  border-bottom: 1px solid var(--line);
+}
+.install-top button {
+  border: none;
+  background: transparent;
+  font-size: 11px;
+  color: var(--blue);
+  padding: 8px;
+  cursor: pointer;
+}
+.install-panel pre {
+  padding: 21px;
+  margin: 0;
+  overflow: auto;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  font-size: 12px;
+  line-height: 1.8;
+  min-height: 81px;
+}
+.install-panel > p {
+  padding: 0 21px 20px;
+  font-size: 10px;
+  line-height: 1.8;
+  color: var(--muted);
+}
+.start-links {
+  display: grid;
+  align-content: center;
+}
+.start-links a {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 14px;
+  padding: 19px 0;
+  border-bottom: 1px solid var(--line);
+}
+.start-links a:hover {
+  color: var(--blue);
+}
+.start-note {
+  text-align: center;
+  font-size: 11px;
+  color: var(--muted);
+  margin-top: 29px;
+  line-height: 1.9;
+}
+.footer {
+  border-top: 1px solid var(--line);
+  padding-block: 33px 28px;
+  display: grid;
+  grid-template-columns: 1fr 1fr auto;
+  gap: 22px;
+  align-items: center;
+}
+.footer .brand {
+  font-size: 20px;
+}
+.footer > p {
+  font-size: 12px;
+  color: var(--muted);
+}
+.footer > div {
+  display: flex;
+  gap: 21px;
+  font-size: 11px;
+}
+.footer small {
+  grid-column: 1/-1;
+  font-size: 10px;
+  color: var(--muted);
+}
+/* Published Markdown pages share the same quiet, readable frame. */
+.document {
+  width: min(840px, calc(100% - 48px));
+  margin: 65px auto 90px;
+  line-height: 1.9;
+  font-size: 15px;
+  overflow-wrap: anywhere;
+}
+.document h1 {
+  font-size: 40px;
+  line-height: 1.4;
+  letter-spacing: -1.5px;
+  margin: 22px 0 32px;
+}
+.document h2 {
+  font-size: 27px;
+  letter-spacing: -0.8px;
+  margin: 36px 0 16px;
+}
+.document h3 {
+  font-size: 21px;
+  margin: 30px 0 13px;
+}
+.document p,
+.document ul,
+.document ol {
+  margin-block: 14px;
+}
+.document a {
+  color: var(--blue);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+.document pre {
+  padding: 20px;
+  background: #edf0f6;
+  overflow: auto;
+  border-radius: 5px;
+  white-space: pre;
+  font-size: 12px;
+}
+.document code {
+  font-size: 0.88em;
+}
+.document blockquote {
+  margin-left: 0;
+  border-left: 3px solid var(--orange);
+  padding-left: 20px;
+  color: var(--muted);
+}
+.table-scroll {
+  overflow: auto;
+}
+.document table {
+  border-collapse: collapse;
+  width: 100%;
+  font-size: 13px;
+}
+.document td,
+.document th {
+  border: 1px solid var(--line);
+  padding: 9px 12px;
+  text-align: left;
+}
+.document hr {
+  border: 0;
+  border-top: 1px solid var(--line);
+  margin-block: 32px;
+}
+.document img {
+  margin: auto;
+}
+.document picture > img {
+  width: 112px;
+}
+@media (min-width: 900px) {
+  .hero-copy h1 {
+    animation: arrive 0.6s both;
+  }
+  .hero-description {
+    animation: arrive 0.7s 0.1s both;
+  }
+  .studio-window {
+    animation: arrive 0.8s 0.15s both;
+  }
+}
+@keyframes arrive {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+@media (max-width: 900px) {
+  .wrap {
+    width: calc(100% - 64px);
+  }
+  .site-header {
+    height: 86px;
+  }
+  .hero-copy {
+    gap: 22px;
+    grid-template-columns: 1fr 1fr;
+    padding-bottom: 42px;
+  }
+  h1 {
+    font-size: 65px;
+    letter-spacing: -4px;
+  }
+  .hero-description {
+    padding: 0;
+  }
+  .hero-description > p:first-child {
+    font-size: 16px;
+  }
+  .actions {
+    gap: 16px;
+    flex-wrap: wrap;
+  }
+  .button {
+    gap: 20px;
+  }
+  .small-note {
+    max-width: 270px;
+    line-height: 1.8;
+  }
+  .film-grid {
+    gap: 20px;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .film:last-child {
+    display: none;
+  }
+  .section-pad {
+    padding-block: 78px;
+  }
+  .work-section {
+    margin-top: 42px;
+  }
+  .section-heading {
+    gap: 24px;
+  }
+  .section-heading > p {
+    font-size: 12px;
+  }
+  .feature-row {
+    gap: 35px;
+    grid-template-columns: 1fr 1fr;
+    padding-block: 36px;
+  }
+  .feature-copy h3 {
+    font-size: 25px;
+  }
+  .feature-copy p {
+    font-size: 12px;
+  }
+  .feature-image {
+    padding: 12px;
+  }
+  .principles-inner {
+    gap: 40px;
+  }
+  .start-grid {
+    gap: 28px;
+    grid-template-columns: 1.2fr 1fr;
+  }
+  .footer {
+    grid-template-columns: 1fr auto;
+  }
+  .footer > p {
+    display: none;
+  }
+}
+@media (max-width: 600px) {
+  .wrap {
+    width: calc(100% - 40px);
+  }
+  .site-header {
+    height: 78px;
+  }
+  .brand {
+    font-size: 21px;
+  }
+  .brand img {
+    width: 33px;
+  }
+  nav {
+    gap: 19px;
+    font-size: 12px;
+  }
+  nav > a:nth-child(2),
+  .nav-github {
+    display: none;
+  }
+  .hero {
+    padding-top: 27px;
+  }
+  .edition {
+    display: none;
+  }
+  .eyebrow {
+    font-size: 10px;
+  }
+  .hero-copy {
+    grid-template-columns: 1fr;
+    gap: 28px;
+    padding-top: 29px;
+    padding-bottom: 35px;
+  }
+  h1 {
+    font-size: 64px;
+    line-height: 1.16;
+    letter-spacing: -4px;
+  }
+  .hero-description > p:first-child {
+    font-size: 16px;
+    line-height: 1.85;
+  }
+  .actions {
+    margin-top: 22px;
+    gap: 21px;
+  }
+  .button {
+    padding: 14px 19px;
+    min-height: 48px;
+  }
+  .small-note {
+    max-width: none;
+    font-size: 9px;
+    margin-top: 17px;
+  }
+  .window-bar {
+    padding: 9px 10px;
+    font-size: 6px;
+    letter-spacing: 1px;
+  }
+  .window-local {
+    display: none;
+  }
+  .window-dots {
+    width: 45px;
+    gap: 4px;
+  }
+  .window-dots i {
+    width: 4px;
+    height: 4px;
+  }
+  .window-bar > span:nth-child(2) {
+    margin-right: auto;
+    margin-left: auto;
+    transform: translateX(-22px);
+  }
+  .studio-window {
+    border-radius: 7px;
+  }
+  .studio-window figcaption {
+    padding: 11px;
+    font-size: 9px;
+  }
+  .studio-window figcaption > span:last-child {
+    display: none;
+  }
+  .studio-window figcaption b {
+    margin-right: 4px;
+  }
+  .hero-foot {
+    font-size: 9px;
+    padding-top: 18px;
+  }
+  .hero-foot span:last-child {
+    display: none;
+  }
+  .section-pad {
+    padding-block: 59px;
+  }
+  .work-section {
+    margin-top: 27px;
+  }
+  .section-heading {
+    display: block;
+    margin-bottom: 28px;
+  }
+  .section-heading .eyebrow {
+    margin-bottom: 15px;
+  }
+  h2 {
+    font-size: 32px;
+    letter-spacing: -1px;
+  }
+  .section-heading > p {
+    margin-top: 17px;
+    font-size: 12px;
+  }
+  .film-grid {
+    grid-template-columns: 1fr;
+    gap: 33px;
+  }
+  .film:last-child {
+    display: block;
+  }
+  .film-meta {
+    padding-top: 17px;
+  }
+  .film-meta h3 {
+    font-size: 23px;
+    min-height: 0;
+    margin-top: 9px;
+  }
+  .film-meta h3 br {
+    display: none;
+  }
+  .film-meta p {
+    margin-top: 8px;
+  }
+  .gallery-link {
+    font-size: 11px;
+    gap: 12px;
+    margin-top: 28px;
+  }
+  .feature-row,
+  .reversed {
+    display: flex;
+    flex-direction: column;
+    gap: 27px;
+    padding-block: 32px;
+    align-items: stretch;
+  }
+  .feature-copy h3 {
+    font-size: 27px;
+    margin-block: 14px;
+  }
+  .feature-copy p {
+    max-width: none;
+    font-size: 13px;
+  }
+  .feature-copy a {
+    margin-top: 15px;
+  }
+  .feature-image {
+    padding: 13px;
+  }
+  .export-note {
+    align-items: start;
+    gap: 16px;
+    padding-top: 26px;
+  }
+  .export-symbol {
+    width: 39px;
+    height: 39px;
+    min-width: 39px;
+    font-size: 23px;
+  }
+  .export-note h3 {
+    font-size: 22px;
+    line-height: 1.5;
+  }
+  .export-note p {
+    font-size: 12px;
+  }
+  .format-label {
+    display: none;
+  }
+  .principles-inner {
+    grid-template-columns: 1fr;
+    gap: 38px;
+  }
+  .principle-list {
+    gap: 22px;
+  }
+  .principle-list > div {
+    gap: 18px;
+    padding-bottom: 22px;
+  }
+  .start-heading {
+    text-align: left;
+  }
+  .start-heading h2 {
+    font-size: 36px;
+    margin-block: 19px;
+  }
+  .start-heading h2 span {
+    display: block;
+  }
+  .start-heading > p:last-child {
+    font-size: 13px;
+  }
+  .start-grid {
+    grid-template-columns: 1fr;
+    gap: 21px;
+    margin-top: 29px;
+  }
+  .start-note {
+    text-align: left;
+    font-size: 10px;
+  }
+  .footer {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+    padding-block: 25px;
+  }
+  .footer > div {
+    width: 100%;
+    gap: 24px;
+    font-size: 11px;
+  }
+  .footer small {
+    font-size: 9px;
+    line-height: 1.8;
+  }
+  .document {
+    margin-top: 35px;
+    font-size: 14px;
+  }
+  .document h1 {
+    font-size: 30px;
+  }
+  .document h2 {
+    font-size: 23px;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+  *,
+  *::before,
+  *::after {
+    animation: none !important;
+    transition: none !important;
+  }
+}

--- a/docs/assets/site.js
+++ b/docs/assets/site.js
@@ -1,0 +1,21 @@
+const copy = document.querySelector("#copy-command");
+copy?.addEventListener("click", async () => {
+  const status = document.querySelector("#copy-status");
+  try {
+    await navigator.clipboard.writeText(
+      document.querySelector("#clone-command").textContent,
+    );
+    status.textContent = "已复制。按照安装文档继续配置环境。";
+    copy.textContent = "已复制 ✓";
+  } catch {
+    status.textContent = "未能访问剪贴板，请选中上方命令手动复制。";
+  }
+});
+// Play one example at a time; playback always starts with an explicit user action.
+document.querySelectorAll("video").forEach((video) => {
+  video.addEventListener("play", () => {
+    document.querySelectorAll("video").forEach((other) => {
+      if (other !== video) other.pause();
+    });
+  });
+});

--- a/docs/github-settings.md
+++ b/docs/github-settings.md
@@ -62,6 +62,10 @@ Protect `master` with:
   - `Frontend tests, build and audit`
   - `Repository hygiene`
   - `Real full-stack Playwright`
+  - `Filesystem (windows-latest)`
+  - `Filesystem (macos-latest)`
+  - `Workflow and secret checks`
+  - `Website build and browser checks`
 - Block force pushes.
 - Block branch deletion.
 - Apply protection to administrators; require resolved discussions. Single-maintainer PRs do not require a second approver; external PRs need maintainer review.

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1,0 +1,106 @@
+# 开始使用 InsightCut
+
+InsightCut 在自己的电脑上运行。这里是介绍与文档网站；启动本地服务后，在浏览器打开工作台。
+
+## 准备环境
+
+- Python **3.11**、Node.js **22** 与 npm。
+- 系统 PATH 中的 **FFmpeg** 和 **ffprobe**。PDF 文稿提取另需 Poppler 的 **pdftotext**。
+- 用于生成文字、图片和配音的服务商账号与凭证。项目本身使用 MIT 许可证，模型调用可能产生服务商费用。
+
+先验证工具可用：
+
+```sh
+node --version
+ffmpeg -version
+ffprobe -version
+```
+
+macOS 可使用 Homebrew 安装 FFmpeg 和 Poppler。Windows 可使用对应项目的安装包并将工具目录加入 PATH。更详细的依赖与测试说明见[贡献指南](../CONTRIBUTING.md)。
+
+## 1. 获取源码
+
+```sh
+git clone https://github.com/SkyNotSilent/insightcut-jianying-image-video.git
+cd insightcut-jianying-image-video
+```
+
+## 2. 配置后端
+
+在项目根目录，macOS / Linux 运行：
+
+```sh
+cd ai-kepu-video-server
+python3.11 -m venv venv311
+source venv311/bin/activate
+python -m pip install -r requirements-dev.lock --require-hashes
+cp .env.example .env
+```
+
+Windows PowerShell 运行：
+
+```powershell
+cd ai-kepu-video-server
+py -3.11 -m venv venv311
+.\venv311\Scripts\python.exe -m pip install -r requirements-dev.lock --require-hashes
+Copy-Item .env.example .env
+```
+
+新安装时复制配置示例即可。已有 `.env` 请继续使用，避免覆盖自己的设置。
+
+## 3. 启动服务
+
+在后端目录启动，仅监听本机：
+
+macOS / Linux（已激活虚拟环境）：
+
+```sh
+python -m uvicorn api_server:app --host 127.0.0.1 --port 2002 --reload
+```
+
+Windows PowerShell：
+
+```powershell
+.\venv311\Scripts\python.exe -m uvicorn api_server:app --host 127.0.0.1 --port 2002 --reload
+```
+
+再开一个终端，从项目根目录运行：
+
+```sh
+cd ai-kepu-video-web/frontend
+npm ci
+npm run dev
+```
+
+打开 [本地工作台](http://localhost:2001)。后端健康检查位于 [localhost:2002/health](http://localhost:2002/health)。这两个地址只在你已启动本地服务时可用。
+
+## 4. 连接模型服务商
+
+打开工作台的“设置”：
+
+1. 配置生文服务商、凭证与模型。
+2. 配置生图服务商与凭证。
+3. 启用豆包、MiMo 或两者，选择开放音色和配音参数。
+4. 保存配置。需要克隆声音时，先确认声音授权、上传参考录音并完成试听。
+
+项目与素材保存在本机；生成所需文本或参考素材会发送给所选服务商。不要在 Issue、日志截图或代码中分享 API Key。
+
+## 5. 完成第一条视频
+
+输入主题，或粘贴完整文稿 → 生成预案 → 按需预览和编辑 → **确认并生成视频**。
+
+确认后，图片、配音与 MP4 会在后台连续推进。预览和试听可选；剪映草稿只在请求导出时构建。失败时，先检查具体阶段的错误，已有素材继续保留。
+
+批量预案支持同批 **2–50** 个主题或完整文稿，同时运行数 **1–10**；FFmpeg 视频渲染单独排队。参见[批量预案与成片流程](batch-video-workflow.md)。
+
+## 6. 导出并继续剪辑
+
+成片可以下载为 MP4，也可以在导出页请求剪映 / CapCut 草稿，选择自己习惯的本机目录。同名草稿默认另存副本；选择替换时保留备份。
+
+剪映版本差异可能影响导入，请在客户端实际打开确认。项目与剪映、CapCut 无隶属或合作关系。备份与恢复说明见[内容保护与可靠性](reliability-remediation.md)。
+
+## 遇到问题
+
+- [公开问题反馈](https://github.com/SkyNotSilent/insightcut-jianying-image-video/issues)：附上复现步骤、系统版本和脱敏后的错误。
+- [安全问题反馈](../SECURITY.md)：敏感内容走私密渠道。
+- [参与贡献](../CONTRIBUTING.md)：Fork、分支、测试和 PR 的完整流程。

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,336 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>InsightCut · 让想法，有画面</title>
+    <meta
+      name="description"
+      content="本地优先、可编辑、可恢复的 AI 图片视频工作台。从主题或完整文稿出发，生成分镜、图片、配音、字幕和 MP4，按需导出剪映草稿。MIT 开源。"
+    />
+    <meta name="theme-color" content="#315FEA" />
+    <meta property="og:title" content="InsightCut · 让想法，有画面" />
+    <meta
+      property="og:description"
+      content="从一句主题到一条视频。每段文字、每幅画面，都留给你继续创作。"
+    />
+    <meta property="og:type" content="website" />
+    <link rel="icon" type="image/svg+xml" href="assets/insightcut-mark.svg" />
+    <link rel="stylesheet" href="assets/site.css" />
+    <script src="assets/site.js" defer></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">跳到正文</a>
+    <header class="site-header wrap">
+      <a class="brand" href="./" aria-label="InsightCut 首页"
+        ><img
+          src="assets/insightcut-mark.svg"
+          width="40"
+          height="40"
+          alt=""
+        /><span>InsightCut<span class="brand-dot">.</span></span></a
+      >
+      <nav aria-label="主导航">
+        <a href="#work">作品</a><a href="#studio">工作台</a
+        ><a href="guide.html">文档</a
+        ><a
+          class="nav-github"
+          href="https://github.com/SkyNotSilent/insightcut-jianying-image-video"
+          >GitHub <span aria-hidden="true">↗</span></a
+        >
+      </nav>
+    </header>
+    <main id="main">
+      <section class="hero wrap" aria-labelledby="hero-title">
+        <div class="hero-topline">
+          <span class="eyebrow"
+            ><span class="status-dot"></span>你的本地 AI 视频工作台</span
+          ><span class="edition">OPEN SOURCE / MIT</span>
+        </div>
+        <div class="hero-copy">
+          <h1 id="hero-title">
+            让想法，<br /><span
+              >有画面<span class="orange-period">。</span></span
+            >
+          </h1>
+          <div class="hero-description">
+            <p>
+              一句主题，一篇文稿。<br />从分镜、画面到配音和成片，<br />把创作连起来，把选择留给你。
+            </p>
+            <div class="actions">
+              <a class="button primary" href="#start"
+                >开始创作 <span aria-hidden="true">↗</span></a
+              ><a class="text-link" href="#work"
+                >先看真实作品 <span aria-hidden="true">↓</span></a
+              >
+            </div>
+            <p class="small-note">
+              本机运行 · 素材可编辑 · 剪映 / CapCut 草稿导出
+            </p>
+          </div>
+        </div>
+        <figure class="studio-window">
+          <div class="window-bar">
+            <span class="window-dots" aria-hidden="true"
+              ><i></i><i></i><i></i></span
+            ><span>INSIGHTCUT STUDIO</span
+            ><span class="window-local">LOCAL WORKSPACE</span>
+          </div>
+          <img
+            src="screenshots/workspace.png"
+            width="2940"
+            height="1618"
+            alt="InsightCut 工作台真实截图：左侧分镜列表，中间毛毡风画面预览，右侧画面和配音设置"
+            fetchpriority="high"
+          />
+          <figcaption>
+            <span><b>01 —</b> 从想法到作品，始终在你的工作台里。</span
+            ><span>实际产品界面</span>
+          </figcaption>
+        </figure>
+        <div class="hero-foot">
+          <span>为科普、故事与知识表达而做</span
+          ><span>文字 → 分镜 → 画面与声音 → 视频</span>
+        </div>
+      </section>
+
+      <section id="work" class="work-section section-pad">
+        <div class="wrap">
+          <div class="section-heading">
+            <div>
+              <p class="eyebrow">MADE WITH INSIGHTCUT</p>
+              <h2>先看作品，<br />再聊可能。</h2>
+            </div>
+            <p>来自真实本地任务的成片。<br />按下播放，听见文字，看到想法。</p>
+          </div>
+          <div class="film-grid">
+            <article class="film">
+              <div class="film-player">
+                <video
+                  controls
+                  playsinline
+                  preload="none"
+                  poster="showcase/thumbs/who-am-i-16x9.jpg"
+                  src="showcase/videos/who-am-i-16x9.mp4"
+                  aria-label="播放：我是谁，我在哪，我要去何方"
+                ></video
+                ><span class="film-index" aria-hidden="true">01</span>
+              </div>
+              <div class="film-meta">
+                <span>一句主题 / 毛毡风 / 16:9</span>
+                <h3>我是谁？我在哪？<br />我要去何方？</h3>
+                <p>从 14 字的提问，展开一段温暖的自我对话。</p>
+              </div>
+            </article>
+            <article class="film">
+              <div class="film-player">
+                <video
+                  controls
+                  playsinline
+                  preload="none"
+                  poster="showcase/thumbs/book-16x9.jpg"
+                  src="showcase/videos/book-16x9.mp4"
+                  aria-label="播放：小岛经济学"
+                ></video
+                ><span class="film-index" aria-hidden="true">02</span>
+              </div>
+              <div class="film-meta">
+                <span>完整文稿 / 毛毡风 / 16:9</span>
+                <h3>小岛经济学</h3>
+                <p>保留原文，用画面把抽象的知识慢慢讲清楚。</p>
+              </div>
+            </article>
+            <article class="film">
+              <div class="film-player">
+                <video
+                  controls
+                  playsinline
+                  preload="none"
+                  poster="showcase/thumbs/thirty-years-16x9.jpg"
+                  src="showcase/videos/thirty-years-16x9.mp4"
+                  aria-label="播放：三十年河东，三十年河西"
+                ></video
+                ><span class="film-index" aria-hidden="true">03</span>
+              </div>
+              <div class="film-meta">
+                <span>一句主题 / 插画风 / 16:9</span>
+                <h3>三十年河东，<br />三十年河西。</h3>
+                <p>用一段熟悉的话，开启一个新的故事。</p>
+              </div>
+            </article>
+          </div>
+          <a class="text-link gallery-link" href="showcase/"
+            >进入完整展厅，看看竖屏与更多风格
+            <span aria-hidden="true">↗</span></a
+          >
+        </div>
+      </section>
+
+      <section id="studio" class="studio-section wrap section-pad">
+        <div class="section-heading">
+          <div>
+            <p class="eyebrow">YOUR IDEAS. YOUR EDIT.</p>
+            <h2>生成只是开始。<br />创作一直由你掌握。</h2>
+          </div>
+          <p>
+            每段文字、每个分镜都能继续调整。<br />保留过程，也保留灵感改变的余地。
+          </p>
+        </div>
+        <div class="feature-row">
+          <div class="feature-copy">
+            <span class="step-number">01 / 构思</span>
+            <h3>从一句话出发，<br />或带上你的全文。</h3>
+            <p>
+              主题模式帮你展开想法；完整文稿模式保留原文。批量预案支持每批 2–50
+              个项目，先看方案，再确认生产。
+            </p>
+            <a class="text-link" href="batch-video-workflow.html"
+              >了解批量预案 <span aria-hidden="true">↗</span></a
+            >
+          </div>
+          <a
+            class="feature-image"
+            href="screenshots/manuscript.png"
+            aria-label="查看完整文稿页截图"
+            ><img
+              src="screenshots/manuscript.png"
+              width="2940"
+              height="1618"
+              alt="文稿页：选择主题或脚本，输入正文并设置生成参数"
+              loading="lazy"
+          /></a>
+        </div>
+        <div class="feature-row reversed">
+          <div class="feature-copy">
+            <span class="step-number">02 / 打磨</span>
+            <h3>改一处细节，<br />不用从头来过。</h3>
+            <p>
+              文稿、提示词、图片和配音独立管理。可以换一张图、重配一段声音，也可以在中断后，接着已有素材继续做。
+            </p>
+            <a class="text-link" href="reliability-remediation.html"
+              >了解保存与恢复 <span aria-hidden="true">↗</span></a
+            >
+          </div>
+          <a
+            class="feature-image"
+            href="screenshots/assets.png"
+            aria-label="查看完整项目资产页截图"
+            ><img
+              src="screenshots/assets.png"
+              width="2940"
+              height="1618"
+              alt="项目资产页：保留各项目的素材、预案和生成进度"
+              loading="lazy"
+          /></a>
+        </div>
+        <div class="export-note">
+          <div class="export-symbol" aria-hidden="true">↗</div>
+          <div>
+            <span class="step-number">03 / 交付</span>
+            <h3>成片可以带走，工程也可以。</h3>
+            <p>
+              确认后连续生成图片、配音和
+              MP4。按需下载视频、字幕与素材包，或导出剪映 / CapCut
+              草稿继续精修。
+            </p>
+          </div>
+          <span class="format-label">MP4<br />SRT / VTT<br />剪映草稿</span>
+        </div>
+      </section>
+
+      <section class="principles section-pad">
+        <div class="wrap principles-inner">
+          <div>
+            <p class="eyebrow">A LITTLE MORE CONTROL</p>
+            <h2>你的创作，<br />留在你的工作空间。</h2>
+          </div>
+          <div class="principle-list">
+            <div>
+              <span>01</span>
+              <div>
+                <h3>本地优先</h3>
+                <p>
+                  项目数据库、媒体与导出文件保存在本机。生成时使用你配置的模型服务商。
+                </p>
+              </div>
+            </div>
+            <div>
+              <span>02</span>
+              <div>
+                <h3>参数属于这个项目</h3>
+                <p>
+                  应用预案模板时保存参数快照。模板可以共用，单条与批量的当前设置各自独立。
+                </p>
+              </div>
+            </div>
+            <div>
+              <span>03</span>
+              <div>
+                <h3>开放，也欢迎一起改进</h3>
+                <p>
+                  MIT
+                  许可证。代码、文档与贡献流程公开，欢迎带着具体问题和想法加入。
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="start" class="start-section wrap section-pad">
+        <div class="start-heading">
+          <p class="eyebrow">MAKE ROOM FOR YOUR NEXT IDEA</p>
+          <h2>下一条，<span>从你开始。</span></h2>
+          <p>在自己的电脑上启动 InsightCut，配置模型服务商，就能开始创作。</p>
+        </div>
+        <div class="start-grid">
+          <div class="install-panel">
+            <div class="install-top">
+              <span>获取源码</span
+              ><button type="button" id="copy-command">
+                复制命令 <span aria-hidden="true">⧉</span>
+              </button>
+            </div>
+            <pre><code id="clone-command">git clone https://github.com/SkyNotSilent/insightcut-jianying-image-video.git</code></pre>
+            <p id="copy-status" role="status" aria-live="polite">
+              Python 3.11 · Node.js 22 · FFmpeg / ffprobe
+            </p>
+          </div>
+          <div class="start-links">
+            <a href="guide.html"
+              >安装与快速开始 <span aria-hidden="true">↗</span></a
+            ><a href="contributing.html"
+              >参与贡献 <span aria-hidden="true">↗</span></a
+            ><a
+              href="https://github.com/SkyNotSilent/insightcut-jianying-image-video"
+              >在 GitHub 查看源码 <span aria-hidden="true">↗</span></a
+            >
+          </div>
+        </div>
+        <p class="start-note">
+          这里是项目介绍与文档站。工作台在本机运行；模型服务的可用性与费用由所选服务商决定。
+        </p>
+      </section>
+    </main>
+    <footer class="footer wrap">
+      <a class="brand" href="./"
+        ><img
+          src="assets/insightcut-mark.svg"
+          width="32"
+          height="32"
+          alt=""
+        /><span>InsightCut<span class="brand-dot">.</span></span></a
+      >
+      <p>给想法画面，给创作余地。</p>
+      <div>
+        <a href="license.html">MIT License</a
+        ><a href="security.html">安全反馈</a
+        ><a
+          href="https://github.com/SkyNotSilent/insightcut-jianying-image-video/issues"
+          >问题反馈</a
+        >
+      </div>
+      <small>独立开源项目，与剪映、CapCut 无隶属或合作关系。</small>
+    </footer>
+  </body>
+</html>

--- a/scripts/build_site.py
+++ b/scripts/build_site.py
@@ -1,0 +1,106 @@
+"""Build a static Pages site from tracked public docs, preserving legacy routes."""
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import os
+from pathlib import Path
+import posixpath
+import re
+import shutil
+import subprocess
+from urllib.parse import quote, unquote, urlsplit, urlunsplit
+
+from markdown_it import MarkdownIt
+
+ROOT = Path(__file__).resolve().parents[1]
+REPO_URL = 'https://github.com/SkyNotSilent/insightcut-jianying-image-video'
+ROOT_PAGES = {'README.md': 'readme.html', 'README_EN.md': 'readme-en.html',
+              'CONTRIBUTING.md': 'contributing.html', 'SECURITY.md': 'security.html', 'LICENSE': 'license.html'}
+
+
+def destination(name):
+    if name in ROOT_PAGES:
+        return ROOT_PAGES[name]
+    if name.startswith('docs/'):
+        name = name[5:]
+        return str(Path(name).with_suffix('.html')) if name.endswith('.md') else name
+    return None
+
+
+def rewrite_reference(raw, source, output, known):
+    parts = urlsplit(html.unescape(raw))
+    if parts.scheme or parts.netloc or not parts.path:
+        return raw
+    source_target = posixpath.normpath(posixpath.join(posixpath.dirname(source), unquote(parts.path)))
+    target = destination(source_target)
+    if source_target in {'docs', 'docs/'}:
+        target = 'documentation.html'
+    if target is not None and (source_target in known or source_target in {'docs', 'docs/'}):
+        relative = posixpath.relpath(target, posixpath.dirname(output) or '.')
+        return html.escape(urlunsplit(('', '', quote(relative), parts.query, parts.fragment)), quote=True)
+    # Repository source links remain browsable without copying source or runtime data.
+    return html.escape(f'{REPO_URL}/blob/master/{quote(source_target)}' + (f'#{parts.fragment}' if parts.fragment else ''), quote=True)
+
+
+def page_shell(title, content, output):
+    prefix = posixpath.relpath('.', posixpath.dirname(output) or '.') + '/'
+    return f'''<!doctype html><html lang="zh-CN"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>{html.escape(title)} · InsightCut</title><link rel="icon" href="{prefix}assets/insightcut-mark.svg"><link rel="stylesheet" href="{prefix}assets/site.css"></head><body><a class="skip-link" href="#main">跳到正文</a><header class="site-header wrap"><a class="brand" href="{prefix}"><img src="{prefix}assets/insightcut-mark.svg" width="40" height="40" alt=""><span>InsightCut<span class="brand-dot">.</span></span></a><nav aria-label="主导航"><a href="{prefix}guide.html">开始使用</a><a href="{prefix}documentation.html">全部文档</a><a href="{REPO_URL}">GitHub ↗</a></nav></header><main id="main" class="document">{content}</main><footer class="footer wrap"><a class="brand" href="{prefix}">InsightCut.</a><p>给想法画面，给创作余地。</p><div><a href="{prefix}contributing.html">参与贡献</a><a href="{prefix}license.html">MIT License</a></div></footer></body></html>'''
+
+
+def render_markdown(text):
+    md = MarkdownIt('commonmark', {'html': True}).enable('table')
+    tokens = md.parse(text)
+    used = {}
+    for index, token in enumerate(tokens):
+        if token.type == 'heading_open':
+            title = tokens[index + 1].content
+            slug = re.sub(r'[^\w\-\s\u4e00-\u9fff]', '', title.lower()).replace(' ', '-')
+            count = used.get(slug, 0)
+            used[slug] = count + 1
+            token.attrSet('id', slug + (f'-{count}' if count else ''))
+    body = md.renderer.render(tokens, md.options, {})
+    return body.replace('<table>', '<div class="table-scroll"><table>').replace('</table>', '</table></div>')
+
+
+def build(output):
+    tracked = subprocess.check_output(['git', 'ls-files', '-z'], cwd=ROOT).decode().split('\0')
+    public = sorted(name for name in tracked if name and (name.startswith('docs/') or name in ROOT_PAGES))
+    if output.exists():
+        # Only the dedicated build directory may be replaced.
+        shutil.rmtree(output)
+    output.mkdir(parents=True)
+    for name in public:
+        source = ROOT / name
+        if source.is_symlink():
+            raise ValueError(f'Public symlinks are not supported: {name}')
+        target = destination(name)
+        dest = output / target
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        if source.suffix == '.md' or name == 'LICENSE':
+            text = source.read_text(encoding='utf-8')
+            title = next((line.lstrip('# ').strip() for line in text.splitlines() if line.startswith('#')), source.stem)
+            body = render_markdown(text) if name != 'LICENSE' else '<h1>MIT License</h1><pre>' + html.escape(text) + '</pre>'
+            body = re.sub(r'(href|src|poster)="([^"]+)"', lambda m: f'{m[1]}="{rewrite_reference(m[2], name, target, public)}"', body)
+            dest.write_text(page_shell(title, body, target), encoding='utf-8')
+        else:
+            shutil.copyfile(source, dest)
+    assert (output / 'index.html').is_file(), 'Track docs/index.html before building'
+    listing = '<h1>项目文档</h1><p>从第一次启动，到批量创作、素材恢复与参与贡献。</p><ul>'
+    for name in public:
+        if name.endswith('.md'):
+            title = next((line.lstrip('# ').strip() for line in (ROOT / name).read_text(encoding='utf-8').splitlines() if line.startswith('#')), Path(name).stem)
+            listing += f'<li><a href="{html.escape(destination(name))}">{html.escape(title)}</a></li>'
+    (output / 'documentation.html').write_text(page_shell('项目文档', listing + '</ul>', 'documentation.html'), encoding='utf-8')
+    (output / '.nojekyll').touch()
+    sha = os.environ.get('INSIGHTCUT_SITE_SHA') or subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=ROOT, text=True).strip()
+    (output / 'build-info.json').write_text(json.dumps({'commit': sha, 'source': REPO_URL}), encoding='utf-8')
+    print(f'Built {len(public)} public files into {output.name}; commit {sha}')
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--output', default='site-dist', choices=['site-dist', 'site-test-dist'])
+    args = parser.parse_args()
+    build(ROOT / args.output)

--- a/scripts/check_site.py
+++ b/scripts/check_site.py
@@ -1,0 +1,51 @@
+"""Validate links and assets in the generated static site without network access."""
+from html.parser import HTMLParser
+from pathlib import Path
+from urllib.parse import unquote, urlsplit
+import sys
+
+
+class References(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.refs = []
+        self.ids = set()
+
+    def handle_starttag(self, tag, attrs):
+        attrs = dict(attrs)
+        for key in ['href', 'src', 'poster']:
+            if key in attrs:
+                self.refs.append(attrs[key])
+        if 'id' in attrs:
+            self.ids.add(attrs['id'])
+
+
+def check(root):
+    errors = []
+    count = 0
+    pages = {}
+    for path in root.rglob('*.html'):
+        doc = References()
+        doc.feed(path.read_text(encoding='utf-8'))
+        pages[path.resolve()] = doc
+    for path, doc in pages.items():
+        for raw in doc.refs:
+            url = urlsplit(raw)
+            if url.scheme or url.netloc:
+                continue
+            target = (path.parent / unquote(url.path)).resolve() if url.path else path
+            if target.is_dir():
+                target /= 'index.html'
+            if not target.is_relative_to(root.resolve()) or not target.is_file():
+                errors.append(f'{path.relative_to(root)}: missing or escaping reference {raw}')
+            elif url.fragment and target in pages and unquote(url.fragment) not in pages[target].ids:
+                errors.append(f'{path.relative_to(root)}: missing anchor {raw}')
+            count += 1
+    if not pages:
+        errors.append('No built HTML pages')
+    print('\n'.join(errors) if errors else f'Site verified: {len(pages)} pages, {count} local references')
+    return bool(errors)
+
+
+if __name__ == '__main__':
+    sys.exit(check(Path(sys.argv[1] if len(sys.argv) > 1 else 'site-dist').resolve()))

--- a/scripts/serve_site.mjs
+++ b/scripts/serve_site.mjs
@@ -1,0 +1,28 @@
+// Local QA server: serves only the built site, including seekable video ranges.
+import http from 'node:http'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../site-dist')
+const types = { '.html': 'text/html; charset=utf-8', '.css': 'text/css', '.js': 'text/javascript', '.svg': 'image/svg+xml', '.png': 'image/png', '.jpg': 'image/jpeg', '.mp4': 'video/mp4', '.json': 'application/json' }
+http.createServer((req, res) => {
+  try {
+    let file = path.resolve(root, `.${decodeURIComponent(new URL(req.url, 'http://localhost').pathname)}`)
+    if (file !== root && !file.startsWith(root + path.sep)) { res.writeHead(403).end(); return }
+    if (fs.statSync(file).isDirectory()) file = path.join(file, 'index.html')
+    const size = fs.statSync(file).size
+    const headers = { 'Content-Type': types[path.extname(file)] || 'application/octet-stream', 'Accept-Ranges': 'bytes' }
+    const range = req.headers.range?.match(/^bytes=(\d+)-(\d*)$/)
+    let start = 0, end = size - 1
+    if (req.headers.range && !range) { res.writeHead(416, { 'Content-Range': `bytes */${size}` }).end(); return }
+    if (range) {
+      start = Number(range[1]); end = range[2] ? Math.min(Number(range[2]), size - 1) : size - 1
+      if (start > end || start >= size) { res.writeHead(416, { 'Content-Range': `bytes */${size}` }).end(); return }
+      headers['Content-Range'] = `bytes ${start}-${end}/${size}`
+    }
+    headers['Content-Length'] = end - start + 1
+    res.writeHead(range ? 206 : 200, headers)
+    if (req.method === 'HEAD') res.end()
+    else fs.createReadStream(file, { start, end }).pipe(res)
+  } catch { res.writeHead(404).end('Not found') }
+}).listen(2104, '127.0.0.1', () => console.log('Site preview: http://127.0.0.1:2104'))


### PR DESCRIPTION
## 网站

为 GitHub Pages 增加独立的 InsightCut 产品首页，使用原有图标、蓝橙配色、真实工作台截图和可播放的本地案例。提供安装、完整文档、贡献与安全反馈入口。保留 /showcase/ 和原 Markdown 文档的 .html 路径；这里只是产品介绍与文档站，应用仍在本机运行。

构建器仅复制 Git 登记的公开文档和静态素材，生成发布 SHA；离线链接检查及浏览器检查覆盖 390/768/1440 宽度、实际播放和拖动、复制命令、键盘和旧路径。页面尊重减少动态效果偏好，视频不会自动播放。

## 验证

本地 17 页、249 个本地引用检查通过；6 项网站浏览器测试通过，无横向溢出，真实视频播放推进和拖动正常。完整桌面、平板、手机截图与失败 trace 会上传为 website-evidence，可由 Actions 下载。已验证一次人为失败使非草稿 PR 标为 BLOCKED，失败截图和完整 trace 可下载；随后删除探针，运行 34731572905 的 8 项检查全部通过。截图位于该运行的 website-evidence。

Pages 的 CI 成功后部署接线将在下一独立 PR 完成。
