### PR TITLE
ci: CI 全绿后发布 Pages 并验证公开产物

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,7 @@ jobs:
         run: |
           python scripts/check_contribution.py
           python scripts/test_contribution.py
+          python scripts/test_pages_gate.py
       - name: Check public repository assets
         run: python scripts/check_readme_assets.py
       - name: Check tracked local-only paths

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,108 @@
+name: Publish Pages
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [master]
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: github-pages
+  cancel-in-progress: false
+
+jobs:
+  gate:
+    name: Verify successful master CI
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'master' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      publish: ${{ steps.gate.outputs.publish }}
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+      - name: Verify exact commit and every CI job
+        id: gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$RUN_ID" > "$RUNNER_TEMP/ci-run.json"
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$RUN_ID/jobs?per_page=100" > "$RUNNER_TEMP/ci-jobs.json"
+          gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/master" --jq .object.sha > "$RUNNER_TEMP/master-sha"
+          python scripts/pages_gate.py "$RUNNER_TEMP/ci-run.json" "$RUNNER_TEMP/ci-jobs.json" "$RUNNER_TEMP/master-sha" >> "$GITHUB_OUTPUT"
+
+  deploy:
+    name: Publish verified static site
+    needs: gate
+    if: needs.gate.outputs.publish == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      actions: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Download only the triggering successful CI artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: pages-site
+          path: site
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+      - name: Verify artifact identity and current head immediately before publishing
+        env:
+          EXPECTED_SHA: ${{ github.event.workflow_run.head_sha }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python -c 'import json,os; assert json.load(open("site/build-info.json"))["commit"] == os.environ["EXPECTED_SHA"]'
+          test "$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/master" --jq .object.sha)" = "$EXPECTED_SHA"
+      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+        with:
+          path: site
+      - name: Deploy Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+      - name: Verify public pages and deployed commit
+        env:
+          SITE_URL: ${{ steps.deployment.outputs.page_url }}
+          EXPECTED_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          python - <<'PY'
+          import json, os, time, urllib.request
+          base = os.environ['SITE_URL'].rstrip('/') + '/'
+          expected = os.environ['EXPECTED_SHA']
+          for attempt in range(18):
+              try:
+                  info = json.load(urllib.request.urlopen(base + 'build-info.json?commit=' + expected, timeout=15))
+                  if info['commit'] == expected:
+                      break
+              except Exception:
+                  pass
+              time.sleep(10)
+          else:
+              raise SystemExit('Published commit did not become available')
+          for route in ['', 'guide.html', 'contributing.html', 'batch-video-workflow.html', 'showcase/', 'assets/site.css', 'assets/insightcut-mark.svg', 'screenshots/workspace.png']:
+              with urllib.request.urlopen(base + route, timeout=20) as response:
+                  assert response.status == 200, route
+                  assert response.read(128), route
+          request = urllib.request.Request(base + 'showcase/videos/book-16x9.mp4', headers={'Range': 'bytes=0-1023'})
+          with urllib.request.urlopen(request, timeout=20) as response:
+              assert response.status == 206, response.status
+              assert len(response.read()) == 1024
+          print('Verified public homepage, documents, media and commit', expected)
+          PY

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,3 +163,5 @@ npm run dev
 - GitHub Pages 是公开产品介绍与文档站，工作台仍在本机 2001/2002 运行。沿用 `docs/assets/` 品牌素材；案例来自 `docs/showcase/`，禁止把本机运行数据复制到站点。
 - `python scripts/build_site.py` 仅发布 Git 登记的文档与静态资产，构建到 `site-dist/`；`python scripts/check_site.py` 检查全部本地链接。
 - 在前端目录运行 `npx playwright test --config=playwright.site.config.js` 验证 390/768/1440 宽度、真实视频播放与文档，预览服务使用独立端口 2104。
+
+- Pages 发布使用 `.github/workflows/pages.yml`，只接收本仓库 `master` 的成功 push CI；发布前校验 8 项检查、最新 SHA 和构建产物身份，不执行 PR 产物中的代码。失败、PR、过期运行不能部署。配置与回退见 `docs/pages-release.md`。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,3 +163,5 @@ npm run dev
 - GitHub Pages 是公开产品介绍与文档站，工作台仍在本机 2001/2002 运行。沿用 `docs/assets/` 品牌素材；案例来自 `docs/showcase/`，禁止把本机运行数据复制到站点。
 - `python scripts/build_site.py` 仅发布 Git 登记的文档与静态资产，构建到 `site-dist/`；`python scripts/check_site.py` 检查全部本地链接。
 - 在前端目录运行 `npx playwright test --config=playwright.site.config.js` 验证 390/768/1440 宽度、真实视频播放与文档，预览服务使用独立端口 2104。
+
+- Pages 发布使用 `.github/workflows/pages.yml`，只接收本仓库 `master` 的成功 push CI；发布前校验 8 项检查、最新 SHA 和构建产物身份，不执行 PR 产物中的代码。失败、PR、过期运行不能部署。配置与回退见 `docs/pages-release.md`。

--- a/docs/pages-release.md
+++ b/docs/pages-release.md
@@ -1,0 +1,64 @@
+# Pages 发布、检查与回退
+
+## 公开站点与本地应用
+
+[InsightCut 网站](https://skynotsilent.github.io/insightcut-jianying-image-video/)提供产品介绍、真实案例和文档。FastAPI / React 工作台仍在本机运行，端口为 2002 / 2001；发布网站不会部署用户数据库、媒体目录或模型凭证。
+
+## 贡献到发布的路径
+
+1. 从 `master` 建分支并提交 PR。外部贡献者可 Fork；第一次贡献的 CI 可能需要维护者批准运行。CI 批准与代码审查是两件事。
+2. 8 项必需检查全部通过，所有讨论解决后才能合并。管理员同样受保护；单维护者场景不要求另一个批准者，外部 PR 仍由维护者审查后合并。
+3. 合并后，`CI` 再检查实际的 `master` 提交，构建静态站并上传 `pages-site`。
+4. `Publish Pages` 只接受本仓库、`master`、push 事件产生的成功 CI。门禁检查每一项 CI 均成功，以及提交仍为最新 `master`。
+5. 仅下载该次 CI 的站点文件；发布前再次核对 `build-info.json` 中的 SHA 和当前 `master`。特权部署步骤不执行产物中的代码。
+6. 发布后自动读取公开首页、关键文档、品牌资产、截图、视频 Range 和 `build-info.json`，验证部署内容对应提交。
+
+PR、失败或取消的 CI、手动调度的 CI、过期 `master` 运行都不能发布。Pages 运行串行处理，正在发布的运行不被中途取消。
+
+## 仓库设置
+
+- Pages → Build and deployment → Source：**GitHub Actions**，不再使用 `master:/docs` 的独立 Jekyll 发布。
+- `github-pages` environment 只允许 `master` 部署。
+- Actions 默认 token 为只读。只有发布 job 授予 `pages: write` 和 `id-token: write`。
+- 必需检查名称与[GitHub 设置](github-settings.md)一致；修改名称时同时更新分支保护和 `scripts/pages_gate.py`。
+- 已开启秘密扫描、推送保护、Dependabot 安全更新和私密漏洞反馈。常规依赖更新每周建 PR，不自动合并。
+
+## 本地验证
+
+先安装 `requirements-dev.lock` 和前端锁定依赖。项目根目录：
+
+```sh
+python scripts/check_contribution.py
+python scripts/test_pages_gate.py
+python scripts/build_site.py
+python scripts/check_site.py
+```
+
+前端目录：
+
+```sh
+npx playwright test --config=playwright.site.config.js
+```
+
+新增文档或素材须先 `git add` 才会进入构建。只复制 Git 登记的公开文件，不遍历用户数据目录；保留 `/showcase/` 和原有 Markdown 对应的 `.html` 地址。
+
+## 如何判断真的上线
+
+以 [Publish Pages 运行结果](https://github.com/SkyNotSilent/insightcut-jianying-image-video/actions/workflows/pages.yml)、公开网页和 [build-info.json](https://skynotsilent.github.io/insightcut-jianying-image-video/build-info.json) 为准。CI 通过、分支推送或旧站点返回 200 都不足以证明新版本已发布。
+
+若 `master` 在部署前再次更新，旧运行会跳过或停止发布，等待新提交 CI 成功。网络或 Pages 平台故障可在 Actions 重跑对应 `Publish Pages`；门禁会重新验证原 CI 和最新 SHA，过期版本仍不会发布。
+
+## 故障证据与回退
+
+- CI 中的 `full-stack-evidence` 包含完整媒体摘要与失败诊断，`website-evidence` 包含 390/768/1440 的截图和失败 trace，保存 **7 天**。需要长期排查时及时下载并脱敏。
+- 修复与回退都通过新分支、PR、CI、合并完成。可在新分支执行 `git revert <需要撤回的提交>`，回退后的新提交重新生成站点；不要直接推送或强制重置 `master`。
+- 发布发生错误时，已有站点继续保留。不要为绕过红色 CI 重新启用独立的 `master:/docs` 发布。
+- 本轮未变动本机 Python 服务环境、真实媒体与数据库，无需用户数据迁移。
+
+## 本轮验证记录（2026-09-13）
+
+- [治理与 MIT PR #11](https://github.com/SkyNotSilent/insightcut-jianying-image-video/pull/11)、[CI PR #12](https://github.com/SkyNotSilent/insightcut-jianying-image-video/pull/12)：已通过检查并合并。
+- [CI 运行 34730811650](https://github.com/SkyNotSilent/insightcut-jianying-image-video/actions/runs/34730811650)：后端 426、前端逻辑 139、组件 43、浏览器 7、真实后端 E2E 6 通过；Windows/macOS 文件保护子集通过。完整输出经 ffprobe 检查为 1920×1080、约 1.043 秒并带音轨，涵盖 MP4、SRT、VTT、两类素材包、草稿及副本/备份。
+- [网站 PR #22](https://github.com/SkyNotSilent/insightcut-jianying-image-video/pull/22)执行过一次有意失败演练：[运行 34731411209](https://github.com/SkyNotSilent/insightcut-jianying-image-video/actions/runs/34731411209)。网站检查为失败、非草稿 PR 的 `mergeStateStatus=BLOCKED`；截图、错误上下文及 trace 均成功下载，trace ZIP 完整。临时失败探针随后删除，再执行正常检查。
+- 本地网站验收：390 / 768 / 1440 宽度无横向溢出，图片实际加载，视频播放推进和拖动正常，单次只播放一个案例；键盘、复制命令及原有文档地址通过。
+- 未验收：另一位真实外部贡献者从 Fork 首次提交的完整操作；真实模型服务商的当前质量；真实剪映客户端导入。前者已检查仓库批准策略和无凭证 CI 配置，后二者不由本轮静态网站与假服务商测试代替。

--- a/scripts/pages_gate.py
+++ b/scripts/pages_gate.py
@@ -1,0 +1,34 @@
+"""Fail closed: only a current, successful master push may publish a CI artifact."""
+import json
+import os
+from pathlib import Path
+import sys
+
+REQUIRED_JOBS = {
+    'Backend tests and audit', 'Frontend tests, build and audit',
+    'Repository hygiene', 'Real full-stack Playwright',
+    'Filesystem (windows-latest)', 'Filesystem (macos-latest)',
+    'Workflow and secret checks', 'Website build and browser checks',
+}
+
+
+def may_publish(run, jobs, latest_sha, repository):
+    return (
+        run.get('event') == 'push'
+        and run.get('head_branch') == 'master'
+        and run.get('head_repository', {}).get('full_name') == repository
+        and run.get('path') == '.github/workflows/ci.yml'
+        and run.get('conclusion') == 'success'
+        and run.get('head_sha') == latest_sha
+        and len(latest_sha) == 40
+        and REQUIRED_JOBS <= {job.get('name') for job in jobs}
+        and all(job.get('conclusion') == 'success' for job in jobs)
+    )
+
+
+if __name__ == '__main__':
+    run = json.loads(Path(sys.argv[1]).read_text())
+    jobs = json.loads(Path(sys.argv[2]).read_text())['jobs']
+    sha = Path(sys.argv[3]).read_text().strip()
+    allowed = may_publish(run, jobs, sha, os.environ['GITHUB_REPOSITORY'])
+    print(f'publish={str(allowed).lower()}')

--- a/scripts/test_pages_gate.py
+++ b/scripts/test_pages_gate.py
@@ -1,0 +1,30 @@
+import copy
+import unittest
+from pages_gate import may_publish, REQUIRED_JOBS
+
+
+class PagesGateTests(unittest.TestCase):
+    def setUp(self):
+        self.sha = 'a' * 40
+        self.repo = 'owner/project'
+        self.run = {'event': 'push', 'head_branch': 'master', 'head_repository': {'full_name': self.repo}, 'path': '.github/workflows/ci.yml', 'conclusion': 'success', 'head_sha': self.sha}
+        self.jobs = [{'name': name, 'conclusion': 'success'} for name in REQUIRED_JOBS]
+
+    def test_current_master(self):
+        self.assertTrue(may_publish(self.run, self.jobs, self.sha, self.repo))
+
+    def test_rejects_untrusted_or_failed_runs(self):
+        for change in [{'event': 'pull_request'}, {'event': 'workflow_dispatch'}, {'head_branch': 'feature'}, {'head_repository': {'full_name': 'fork/project'}}, {'path': '.github/workflows/other.yml'}, {'conclusion': 'failure'}, {'head_sha': 'b' * 40}]:
+            with self.subTest(change=change):
+                self.assertFalse(may_publish(self.run | change, self.jobs, self.sha, self.repo))
+
+    def test_rejects_missing_failed_or_skipped_checks(self):
+        self.assertFalse(may_publish(self.run, self.jobs[:-1], self.sha, self.repo))
+        for conclusion in ['failure', 'skipped', 'cancelled', None]:
+            jobs = copy.deepcopy(self.jobs)
+            jobs[0]['conclusion'] = conclusion
+            self.assertFalse(may_publish(self.run, jobs, self.sha, self.repo))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## 发布行为

Pages 现在只在本仓库 master 的 push CI 全部成功后发布。门禁核对 8 项检查、最新 master SHA 与原 CI 产物的 build-info.json；PR、失败、取消、缺失检查和过期运行不能部署。只有发布 job 获得 Pages/OIDC 写权限，不执行下载产物中的代码。

发布后验证公开首页、旧文档路径、品牌图片、视频 Range 与提交 SHA。增加设置、失败证据、回退和本轮验收说明；同步 AGENTS.md / CLAUDE.md。Pages 设置已迁移至 Actions，环境只允许 master。

## 验证

- 门禁 3 组测试覆盖正常发布和 PR、其他来源、失败、跳过、缺项、旧 SHA 拒绝。
- actionlint、贡献文档同步及 diff 检查通过。
- 静态站 18 页、261 个本地引用通过；页面浏览器验收随本 PR CI 再执行。
- 前一网站 PR 已实际验证红色 CI 阻止合并，失败截图/trace 成功下载；恢复后 8 项检查全绿。
- 合并后会核对 master CI、Pages 部署、公开 SHA 和实际浏览器播放，再报告上线。
